### PR TITLE
Add option to disable separation of header and content with an empty line

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/EspressoUtils.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/EspressoUtils.java
@@ -12,30 +12,18 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 import android.widget.ListView;
 import android.widget.Spinner;
-
 import com.orgzly.R;
-
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-import static android.support.test.espresso.Espresso.onData;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.Espresso.*;
 import static android.support.test.espresso.Espresso.pressBack;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.pressKey;
-import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.*;
 import static android.support.test.espresso.matcher.RootMatchers.isDialog;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withHint;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.support.test.espresso.matcher.ViewMatchers.*;
 import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.Matchers.anything;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 
 /*
  * Few espresso-related notes:
@@ -55,10 +43,10 @@ class EspressoUtils {
     static final int SETTINGS_NEW_NOTE_STATE = 25;
     static final int SETTINGS_CREATED_AT = 27;
 
-    static final int SETTINGS_REPOS = 33;
+    static final int SETTINGS_REPOS = 34;
 
-    static final int IMPORT_GETTING_STARTED = 35;
-    static final int SETTINGS_CLEAR_DATABASE = 36;
+    static final int IMPORT_GETTING_STARTED = 36;
+    static final int SETTINGS_CLEAR_DATABASE = 37;
 
     /**
      */

--- a/app/src/main/java/com/orgzly/android/Shelf.java
+++ b/app/src/main/java/com/orgzly/android/Shelf.java
@@ -10,7 +10,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.RemoteException;
 import android.text.TextUtils;
-
 import com.orgzly.BuildConfig;
 import com.orgzly.R;
 import com.orgzly.android.prefs.AppPreferences;
@@ -223,6 +222,8 @@ public class Shelf {
             } else if (mContext.getString(R.string.pref_value_separate_notes_with_new_line_never).equals(prefValue)) {
                 parserSettings.separateNotesWithNewLine = OrgParserSettings.SeparateNotesWithNewLine.NEVER;
             }
+
+            parserSettings.separateHeaderAndContentWithNewLine = AppPreferences.separateHeaderAndContentWithNewLine(mContext);
 
             final OrgParserWriter parserWriter = new OrgParserWriter(parserSettings);
 

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -2,7 +2,6 @@ package com.orgzly.android.prefs;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-
 import com.orgzly.R;
 import com.orgzly.org.OrgStatesWorkflow;
 
@@ -240,6 +239,12 @@ public class AppPreferences {
         return getDefaultSharedPreferences(context).getString(
                 context.getResources().getString(R.string.pref_key_separate_notes_with_new_line),
                 context.getResources().getString(R.string.pref_default_separate_notes_with_new_line));
+    }
+
+    public static boolean separateHeaderAndContentWithNewLine(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_separate_header_and_content_with_new_line),
+                context.getResources().getBoolean(R.bool.pref_default_separate_header_and_content_with_new_line));
     }
 
     /*

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -275,6 +275,9 @@
         <item>@string/pref_value_separate_notes_with_new_line_never</item>
     </string-array>
 
+    <!-- Separate header and content with an empty line -->
+    <string name="pref_key_separate_header_and_content_with_new_line" translatable="false">pref_key_separate_header_and_content_with_new_line</string>
+    <bool name="pref_default_separate_header_and_content_with_new_line" translatable="false">true</bool>
 
 
     <!-- These do not store any data. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,6 +278,8 @@
 
     <string name="org_file_format">Org file format</string>
     <string name="separate_notes_with_new_line">Separate notes with an empty line</string>
+    <string name="separate_header_and_content_with_new_line">Separate header and content</string>
+    <string name="separate_header_and_content_with_new_line_summary">Separate header and content with an empty line</string>
     <string name="add_property">Add property</string>
 
     <string name="priority_a_highest">A (highest priority)</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -187,6 +187,12 @@
             android:entries="@array/separate_notes_with_new_line_names"
             android:entryValues="@array/separate_notes_with_new_line_values"
             android:defaultValue="@string/pref_default_separate_notes_with_new_line"/>
+
+        <CheckBoxPreference
+            android:key="@string/pref_key_separate_header_and_content_with_new_line"
+            android:title="@string/separate_header_and_content_with_new_line"
+            android:summary="@string/separate_header_and_content_with_new_line_summary"
+            android:defaultValue="@bool/pref_default_separate_header_and_content_with_new_line"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/sync">


### PR DESCRIPTION
Fixes #17. Depends on orgzly/org-java#2.