### PR TITLE
Sync after new note is created

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/EspressoUtils.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/EspressoUtils.java
@@ -45,8 +45,10 @@ class EspressoUtils {
 
     static final int SETTINGS_REPOS = 33;
 
-    static final int IMPORT_GETTING_STARTED = 38;
-    static final int SETTINGS_CLEAR_DATABASE = 39;
+    static final int SETTINGS_SYNC_AFTER = 34;
+
+    static final int IMPORT_GETTING_STARTED = 39;
+    static final int SETTINGS_CLEAR_DATABASE = 40;
 
     /**
      */

--- a/app/src/androidTest/java/com/orgzly/android/espresso/SyncingTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/SyncingTest.java
@@ -26,6 +26,7 @@ import static android.support.test.espresso.contrib.DrawerActions.open;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.orgzly.android.espresso.EspressoUtils.closeSoftKeyboardWithDelay;
 import static com.orgzly.android.espresso.EspressoUtils.onActionItemClick;
 import static com.orgzly.android.espresso.EspressoUtils.onListItem;
 import static com.orgzly.android.espresso.EspressoUtils.onSpinnerString;
@@ -72,6 +73,38 @@ public class SyncingTest extends OrgzlyTest {
 
         onView(allOf(withText("booky"), isDisplayed())).perform(click());
         onView(withText("New content")).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void testSyncAfterNoteCreatedPreference() {
+        shelfTestUtils.setupRepo("mock://repo-a");
+        shelfTestUtils.setupRook("mock://repo-a", "mock://repo-a/booky.org", "", "abc", 1234567890000L);
+        activityRule.launchActivity(null);
+        sync();
+
+        // Set preference
+        onActionItemClick(R.id.activity_action_settings, R.string.settings);
+        onListItem(EspressoUtils.SETTINGS_SYNC_AFTER).perform(click());
+
+        // Open book
+        onView(withId(R.id.drawer_layout)).perform(open());
+        onView(allOf(withText(R.string.notebooks), isDisplayed())).perform(click());
+        onView(withId(R.id.fragment_books_container)).check(matches(isDisplayed()));
+        onView(allOf(withText("booky"), isDisplayed())).check(matches(isDisplayed()));
+        onListItem(0).perform(click());
+
+        // Add note
+        onView(withId(R.id.fab)).perform(click());
+        onView(withId(R.id.fragment_note_title))
+                .perform(replaceText("new note created by test"), closeSoftKeyboardWithDelay());
+        onView(withId(R.id.done)).perform(click());
+
+        // Check it is synced
+        onView(withId(R.id.drawer_layout)).perform(open());
+        onView(allOf(withText(R.string.notebooks), isDisplayed())).perform(click());
+        onView(withId(R.id.fragment_books_container)).check(matches(isDisplayed()));
+        onView(allOf(withText("booky"), isDisplayed())).check(matches(isDisplayed()));
+        onView(allOf(withId(R.id.item_book_modified_after_sync_icon))).check(matches(not(isDisplayed())));
     }
 
     @Test

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -457,4 +457,10 @@ public class AppPreferences {
         String key = context.getResources().getString(R.string.pref_key_reminder_service_last_run);
         return getStateSharedPreferences(context).getLong(key, 0L);
     }
+
+    public static boolean syncAfterNewNoteCreated(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_sync_after),
+                context.getResources().getBoolean(R.bool.pref_default_value_sync_after));
+    }
 }

--- a/app/src/main/java/com/orgzly/android/ui/fragments/SyncFragment.java
+++ b/app/src/main/java/com/orgzly/android/ui/fragments/SyncFragment.java
@@ -956,6 +956,13 @@ public class SyncFragment extends Fragment {
             @Override
             protected void onPostExecute(Note createdNote) {
                 if (createdNote != null) {
+
+                    if (AppPreferences.syncAfterNewNoteCreated(getContext())) {
+                        Intent intent = new Intent(getActivity(), SyncService.class);
+                        intent.setAction(AppIntent.ACTION_SYNC_START);
+                        getActivity().startService(intent);
+                    }
+
                     mListener.onNoteCreated(createdNote);
                 } else {
                     mListener.onNoteCreatingFailed();

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -203,6 +203,9 @@
     <string name="pref_key_min_priority" translatable="false">pref_key_min_priority</string>
     <string name="pref_default_min_priority" translatable="false">C</string>
 
+    <string name="pref_key_sync_after">pref_key_sync_after</string>
+    <bool name="pref_default_value_sync_after" translatable="false">false</bool>
+
     <string-array name="priorities">
         <item>@string/priority_a_highest</item>
         <item>B</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -382,6 +382,9 @@
     <string name="select_a_filter">Select a filter</string>
     <string name="select_a_filter_long">Select a filter by clicking on the title bar</string>
 
+    <string name="sync_after_preference_title">Automatically sync after new notes</string>
+    <string name="sync_after_summary">Automatically sync after new note is created.</string>
+
     <!-- These are just used in tools:text for layout preview and don't have to be translated,
          unless layout look depends on the translation. -->
     <string name="book_mtime_sample">Jul 3, 2013 9:45:37 PM</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -195,6 +195,13 @@
                 android:targetPackage="com.orgzly"
                 android:targetClass="com.orgzly.android.ui.ReposActivity"/>
         </Preference>
+
+        <CheckBoxPreference
+            android:title="@string/sync_after_preference_title"
+            android:key="@string/pref_key_sync_after"
+            android:summary="@string/sync_after_summary"
+            android:defaultValue="@bool/pref_default_value_sync_after"
+            />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/prefs_title_notifications">


### PR DESCRIPTION
Hi,

I added the the option to sync after a new note is created. 

It works but sometimes it has a problem. As I really want to start understanding the project I would really appreciate if someone would take a look and tell me what is wrong. Sometimes after new note creation, `BooksClient.isModifiedAfterLastSync()` is still true therefore the out-of-date indicator besides notebook is visible. It only happens on my emulator while it works fine on my actual phone.
 