### PR TITLE
Add sync action to new note notification and add sync notifications

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/EspressoUtils.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/EspressoUtils.java
@@ -47,8 +47,8 @@ class EspressoUtils {
 
     static final int SETTINGS_SYNC_AFTER = 34;
 
-    static final int IMPORT_GETTING_STARTED = 39;
-    static final int SETTINGS_CLEAR_DATABASE = 40;
+    static final int IMPORT_GETTING_STARTED = 40;
+    static final int SETTINGS_CLEAR_DATABASE = 41;
 
     /**
      */

--- a/app/src/main/java/com/orgzly/android/Notifications.java
+++ b/app/src/main/java/com/orgzly/android/Notifications.java
@@ -1,6 +1,5 @@
 package com.orgzly.android;
 
-import android.app.Activity;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -11,15 +10,13 @@ import android.content.IntentFilter;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
-import android.view.View;
 import com.orgzly.BuildConfig;
 import com.orgzly.R;
 import com.orgzly.android.prefs.AppPreferences;
 import com.orgzly.android.sync.SyncService;
 import com.orgzly.android.sync.SyncStatus;
-import com.orgzly.android.ui.CommonActivity;
+import com.orgzly.android.ui.MainActivity;
 import com.orgzly.android.ui.ShareActivity;
-import com.orgzly.android.util.AppPermissions;
 import com.orgzly.android.util.LogUtils;
 
 import java.util.List;
@@ -79,15 +76,11 @@ public class Notifications {
             switch (status.type) {
                 case STARTING:
                     cancelSyncFailedNotification(context);
-                    if (AppPreferences.showSyncNotifications(context)) {
-                        createSyncInProgressNotification(context);
-                    }
                     break;
                 case CANCELED:
                 case FAILED:
                 case NOT_RUNNING:
                 case FINISHED:
-                    cancelSyncInProgressNotification(context);
                     if (AppPreferences.showSyncNotifications(context)) {
                         createSyncFailedNotification(context, status);
                     }
@@ -96,31 +89,25 @@ public class Notifications {
         }
     };
 
-    private static void createSyncInProgressNotification(Context context) {
+    public static Notification createSyncInProgressNotification(Context context) {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
                 .setOngoing(true)
                 .setSmallIcon(R.drawable.ic_sync_white_24dp)
                 .setContentTitle(context.getString(R.string.syncing_in_progress))
                 .setColor(ContextCompat.getColor(context, R.color.notification));
 
-        NotificationManager notificationManager =
-                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-
-        notificationManager.notify(SYNC_IN_PROGRESS, builder.build());
-    }
-
-    private static void cancelSyncInProgressNotification(Context context) {
-        NotificationManager notificationManager =
-                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-
-        notificationManager.cancel(SYNC_IN_PROGRESS);
+        return builder.build();
     }
 
     private static void createSyncFailedNotification(Context context, SyncStatus status) {
+        PendingIntent openOrgzlyPendingIntent = PendingIntent.getActivity(context, 0,
+                new Intent(context, MainActivity.class), PendingIntent.FLAG_UPDATE_CURRENT);
+
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
-                .setSmallIcon(R.drawable.ic_sync_white_24dp)
+                .setSmallIcon(R.drawable.cic_orgzly_notification)
                 .setContentTitle(context.getString(R.string.syncing_failed_title))
-                .setColor(ContextCompat.getColor(context, R.color.notification));
+                .setColor(ContextCompat.getColor(context, R.color.notification))
+                .setContentIntent(openOrgzlyPendingIntent);
 
         if (status.type == SyncStatus.Type.FAILED) {
             builder.setContentText(status.message);

--- a/app/src/main/java/com/orgzly/android/Notifications.java
+++ b/app/src/main/java/com/orgzly/android/Notifications.java
@@ -4,10 +4,12 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
 import com.orgzly.BuildConfig;
 import com.orgzly.R;
+import com.orgzly.android.sync.SyncService;
 import com.orgzly.android.ui.ShareActivity;
 import com.orgzly.android.util.LogUtils;
 
@@ -23,21 +25,29 @@ public class Notifications {
         PendingIntent resultPendingIntent = ShareActivity.createNewNoteIntent(context);
 
         /* Build notification */
-        Notification notification =
-                new NotificationCompat.Builder(context)
-                        .setOngoing(true)
-                        .setSmallIcon(R.drawable.cic_orgzly_notification)
-                        .setContentTitle(context.getString(R.string.new_note))
-                        .setContentText(context.getString(R.string.tap_to_create_new_note))
-                        .setColor(ContextCompat.getColor(context, R.color.notification))
-                        .setContentIntent(resultPendingIntent)
-                        .setPriority(NotificationCompat.PRIORITY_MIN) // Don't show icon on status bar
-                        .build();
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
+                .setOngoing(true)
+                .setSmallIcon(R.drawable.cic_orgzly_notification)
+                .setContentTitle(context.getString(R.string.new_note))
+                .setContentText(context.getString(R.string.tap_to_create_new_note))
+                .setColor(ContextCompat.getColor(context, R.color.notification))
+                .setContentIntent(resultPendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_MIN); // Don't show icon on status bar
+
+        /* add sync action */
+        Intent syncIntent = new Intent(context, SyncService.class);
+        syncIntent.setAction(AppIntent.ACTION_SYNC_START);
+
+        PendingIntent syncPendingIntent = PendingIntent.getService(context, 0, syncIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        builder.addAction(
+                    R.drawable.ic_sync_white_24dp,
+                    context.getString(R.string.sync),
+                    syncPendingIntent);
 
         NotificationManager notificationManager =
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-        notificationManager.notify(ONGOING_NEW_NOTE, notification);
+        notificationManager.notify(ONGOING_NEW_NOTE, builder.build());
     }
 
     public static void cancelNewNoteNotification(Context context) {

--- a/app/src/main/java/com/orgzly/android/Notifications.java
+++ b/app/src/main/java/com/orgzly/android/Notifications.java
@@ -1,23 +1,36 @@
 package com.orgzly.android;
 
+import android.app.Activity;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.content.LocalBroadcastManager;
+import android.view.View;
 import com.orgzly.BuildConfig;
 import com.orgzly.R;
+import com.orgzly.android.prefs.AppPreferences;
 import com.orgzly.android.sync.SyncService;
+import com.orgzly.android.sync.SyncStatus;
+import com.orgzly.android.ui.CommonActivity;
 import com.orgzly.android.ui.ShareActivity;
+import com.orgzly.android.util.AppPermissions;
 import com.orgzly.android.util.LogUtils;
+
+import java.util.List;
 
 public class Notifications {
     public static final String TAG = Notifications.class.getName();
 
     public final static int ONGOING_NEW_NOTE = 1;
     public final static int REMINDER = 2;
+    public final static int SYNC_IN_PROGRESS = 3;
+    public final static int SYNC_FAILED = 4;
 
     public static void createNewNoteNotification(Context context) {
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, context);
@@ -57,4 +70,101 @@ public class Notifications {
         notificationManager.cancel(ONGOING_NEW_NOTE);
     }
 
+
+    private static BroadcastReceiver syncServiceReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            SyncStatus status = SyncStatus.fromIntent(intent);
+
+            switch (status.type) {
+                case STARTING:
+                    cancelSyncFailedNotification(context);
+                    if (AppPreferences.showSyncNotifications(context)) {
+                        createSyncInProgressNotification(context);
+                    }
+                    break;
+                case CANCELED:
+                case FAILED:
+                case NOT_RUNNING:
+                case FINISHED:
+                    cancelSyncInProgressNotification(context);
+                    if (AppPreferences.showSyncNotifications(context)) {
+                        createSyncFailedNotification(context, status);
+                    }
+                    break;
+            }
+        }
+    };
+
+    private static void createSyncInProgressNotification(Context context) {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
+                .setOngoing(true)
+                .setSmallIcon(R.drawable.ic_sync_white_24dp)
+                .setContentTitle(context.getString(R.string.syncing_in_progress))
+                .setColor(ContextCompat.getColor(context, R.color.notification));
+
+        NotificationManager notificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        notificationManager.notify(SYNC_IN_PROGRESS, builder.build());
+    }
+
+    private static void cancelSyncInProgressNotification(Context context) {
+        NotificationManager notificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        notificationManager.cancel(SYNC_IN_PROGRESS);
+    }
+
+    private static void createSyncFailedNotification(Context context, SyncStatus status) {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
+                .setSmallIcon(R.drawable.ic_sync_white_24dp)
+                .setContentTitle(context.getString(R.string.syncing_failed_title))
+                .setColor(ContextCompat.getColor(context, R.color.notification));
+
+        if (status.type == SyncStatus.Type.FAILED) {
+            builder.setContentText(status.message);
+        } else {
+            List<Book> books = new Shelf(context).getBooks();
+
+            StringBuilder sb = new StringBuilder();
+            for (Book book: books) {
+                if (book.getLastAction().getType() == BookAction.Type.ERROR) {
+                    sb.append(book.getName())
+                            .append(": ")
+                            .append(book.getLastAction().getMessage())
+                            .append("\n");
+                }
+            }
+
+            String message = sb.toString().trim();
+
+            if (message.length() == 0) {
+                /* no error, don't show the notification */
+                return;
+            }
+
+            builder.setContentText(message);
+            builder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
+        }
+
+        NotificationManager notificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        notificationManager.notify(SYNC_FAILED, builder.build());
+    }
+
+    private static void cancelSyncFailedNotification(Context context) {
+        NotificationManager notificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        notificationManager.cancel(SYNC_FAILED);
+    }
+
+    public static void ensureSyncNotificationSetup(Context context) {
+        LocalBroadcastManager.getInstance(context).unregisterReceiver(syncServiceReceiver);
+
+        LocalBroadcastManager.getInstance(context)
+                .registerReceiver(syncServiceReceiver, new IntentFilter(AppIntent.ACTION_SYNC_STATUS));
+    }
 }

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -195,6 +195,12 @@ public class AppPreferences {
                 context.getResources().getBoolean(R.bool.pref_default_value_use_reminders_for_scheduled_times));
     }
 
+    public static boolean showSyncNotifications(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_show_sync_notifications),
+                context.getResources().getBoolean(R.bool.pref_default_value_show_sync_notifications));
+    }
+
     public static String colorScheme(Context context) {
         return getDefaultSharedPreferences(context).getString(
                 context.getResources().getString(R.string.pref_key_color_scheme),

--- a/app/src/main/java/com/orgzly/android/sync/SyncService.java
+++ b/app/src/main/java/com/orgzly/android/sync/SyncService.java
@@ -16,6 +16,7 @@ import com.orgzly.BuildConfig;
 import com.orgzly.R;
 import com.orgzly.android.BookAction;
 import com.orgzly.android.AppIntent;
+import com.orgzly.android.Notifications;
 import com.orgzly.android.Shelf;
 import com.orgzly.android.prefs.AppPreferences;
 import com.orgzly.android.repos.DirectoryRepo;
@@ -90,6 +91,8 @@ public class SyncService extends Service {
 
     private void start() {
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG);
+
+        Notifications.ensureSyncNotificationSetup(this);
 
         Map<String, Repo> repos = shelf.getAllRepos();
 

--- a/app/src/main/java/com/orgzly/android/sync/SyncService.java
+++ b/app/src/main/java/com/orgzly/android/sync/SyncService.java
@@ -11,11 +11,10 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
-
 import com.orgzly.BuildConfig;
 import com.orgzly.R;
-import com.orgzly.android.BookAction;
 import com.orgzly.android.AppIntent;
+import com.orgzly.android.BookAction;
 import com.orgzly.android.Notifications;
 import com.orgzly.android.Shelf;
 import com.orgzly.android.prefs.AppPreferences;
@@ -93,6 +92,10 @@ public class SyncService extends Service {
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG);
 
         Notifications.ensureSyncNotificationSetup(this);
+
+        if (AppPreferences.showSyncNotifications(getApplicationContext())) {
+            startForeground(Notifications.SYNC_IN_PROGRESS, Notifications.createSyncInProgressNotification(getApplicationContext()));
+        }
 
         Map<String, Repo> repos = shelf.getAllRepos();
 

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -194,6 +194,9 @@
     <string name="pref_key_use_reminders_for_scheduled_times" translatable="false">pref_key_use_reminders_for_scheduled_times</string>
     <bool name="pref_default_value_use_reminders_for_scheduled_times" translatable="false">false</bool>
 
+    <string name="pref_key_show_sync_notifications" translatable="false">pref_key_show_sync_notifications</string>
+    <bool name="pref_default_value_show_sync_notifications" translatable="false">false</bool>
+
     <string name="pref_key_states" translatable="false">pref_key_states</string>
     <string name="pref_default_states" translatable="false">TODO NEXT | DONE</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,6 +165,7 @@
     <string name="syncing_in_progress">Syncing…</string>
     <string name="syncing_book">Syncing %s…</string>
     <string name="syncing_failed">Sync: %s</string> <!-- Sync: Reason -->
+    <string name="syncing_failed_title">Sync failed</string>
     <string name="canceled">Canceled</string>
     <string name="canceling">Canceling…</string>
     <string name="directory">Directory</string>
@@ -350,8 +351,8 @@
     <string name="display_inherited_tags_in_search_results">Inherited tags in search results</string>
     <string name="display_inherited_tags_in_search_results_summary">Display inherited tags in search results</string>
 
-    <string name="new_note_notification">New note</string>
-    <string name="new_note_notification_summary">Quickly create new note from notification drawer</string>
+    <string name="new_note_notification">New note and sync</string>
+    <string name="new_note_notification_summary">Quickly create new note and sync from notification drawer</string>
 
     <string name="primary_storage">Main storage</string>
     <string name="secondary_storage">SD card</string>
@@ -420,4 +421,6 @@
     <string name="synced_rook_revision_sample">42f97fe238</string>
     <string name="tap_to_view_notes">Tap to view your notes</string>
     <string name="pref_title_scheduled_times">Scheduled times (beta)</string>
+    <string name="show_sync_notifications_title">Show sync notifications</string>
+    <string name="show_sync_notifications_summary">Show a notification during sync and on sync failure</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -215,6 +215,12 @@
             android:key="@string/pref_key_use_reminders_for_scheduled_times"
             android:title="@string/pref_title_scheduled_times"
             android:defaultValue="@bool/pref_default_value_use_reminders_for_scheduled_times"/>
+
+        <CheckBoxPreference
+                android:key="@string/pref_key_show_sync_notifications"
+                android:title="@string/show_sync_notifications_title"
+                android:summary="@string/show_sync_notifications_summary"
+                android:defaultValue="@bool/pref_default_value_show_sync_notifications"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/app">


### PR DESCRIPTION
Fixes #89.

This PR adds a sync action to the ongoing notification and adds two new notifications, related to sync:
- the first is displayed while the sync is running
- the second is displayed, if an error occurred during sync or there are conflicts

The notifications have to be enabled in the settings.