### PR TITLE
add hash-based file sync check

### DIFF
--- a/app/src/main/java/com/orgzly/android/App.java
+++ b/app/src/main/java/com/orgzly/android/App.java
@@ -1,14 +1,23 @@
 package com.orgzly.android;
 
 import android.app.Application;
+import android.content.Context;
 
 import com.evernote.android.job.JobManager;
 
 public class App extends Application {
+
+    private static Context context;
+
     @Override
     public void onCreate() {
         super.onCreate();
 
+        App.context = getApplicationContext();
         JobManager.create(this).addJobCreator(new AppJobCreator());
+    }
+
+    public static Context getAppContext() {
+        return App.context;
     }
 }

--- a/app/src/main/java/com/orgzly/android/sync/SyncService.java
+++ b/app/src/main/java/com/orgzly/android/sync/SyncService.java
@@ -9,7 +9,6 @@ import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.Binder;
 import android.os.IBinder;
-import android.os.SystemClock;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
 import com.orgzly.BuildConfig;
@@ -252,15 +251,6 @@ public class SyncService extends Service {
 
             status.set(SyncStatus.Type.BOOKS_COLLECTED, null, 0, namesakes.size());
             announceActiveSyncStatus();
-
-            /* Because android sometimes drops milliseconds on reported file lastModified,
-             * wait until the next full second
-             */
-            if (isTriggeredAutomatically) {
-                long now = System.currentTimeMillis();
-                long nowMsPart = now % 1000;
-                SystemClock.sleep(1000 - nowMsPart);
-            }
 
             /*
              * Update books' statuses, before starting to sync them.

--- a/app/src/main/java/com/orgzly/android/util/HashUtils.java
+++ b/app/src/main/java/com/orgzly/android/util/HashUtils.java
@@ -1,0 +1,55 @@
+package com.orgzly.android.util;
+
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.security.MessageDigest;
+
+import android.support.v4.provider.DocumentFile;
+
+import com.orgzly.BuildConfig;
+import com.orgzly.android.util.LogUtils;
+
+public enum HashUtils {
+
+    MD5("MD5"),
+    SHA1("SHA1"),
+    SHA256("SHA-256"),
+    SHA512("SHA-512");
+
+    private String name;
+
+    HashUtils(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String checksum(InputStream in) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(getName());
+            byte[] block = new byte[4096];
+            int length;
+            while ((length = in.read(block)) > 0) {
+                digest.update(block, 0, length);
+            }
+            byte[] bytes = digest.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : bytes) {
+                sb.append(String.format("%02X", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String checksum(File file) throws IOException {
+        InputStream instream = new FileInputStream(file);
+        return this.checksum(instream);
+    }
+}


### PR DESCRIPTION
Starting point for hash based file check/sync
During the changeover to hash file revisions, all files will flash as out of date.
This does not solve some of the other race conditions on checks vs applied changes.
I do not like the global context but I do not know a better approach to getting access to the content provider.
