### PR TITLE
Guess at the changes needed for not wrapping content

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
+++ b/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
@@ -181,7 +181,7 @@ public class HeadsListViewAdapter extends SimpleCursorAdapter {
             if (AppPreferences.isFontMonospaced(context)) {
                 holder.content.setTypeface(Typeface.MONOSPACE);
             }
-
+	    /* This is where wrapping needs to be disabled, I guess */
             holder.content.setText(OrgFormatter.parse(context, head.getContent()));
 
             holder.content.setVisibility(View.VISIBLE);
@@ -343,4 +343,3 @@ public class HeadsListViewAdapter extends SimpleCursorAdapter {
         }
     }
 }
-

--- a/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
+++ b/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
@@ -181,7 +181,7 @@ public class HeadsListViewAdapter extends SimpleCursorAdapter {
             if (AppPreferences.isFontMonospaced(context)) {
                 holder.content.setTypeface(Typeface.MONOSPACE);
             }
-	    /* This is where wrapping needs to be disabled, I guess */
+
             holder.content.setText(OrgFormatter.parse(context, head.getContent()));
 
             holder.content.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/orgzly/android/ui/ViewHolder.java
+++ b/app/src/main/java/com/orgzly/android/ui/ViewHolder.java
@@ -72,6 +72,7 @@ public class ViewHolder /* extends RecyclerView.ViewHolder */ {
         closedText = (TextView) itemView.findViewById(R.id.item_head_closed_text);
 
         content = (TextView) itemView.findViewById(R.id.item_head_content);
+	/* This is where the content widget is set up */
 
         menuContainer = (ViewGroup) itemView.findViewById(R.id.item_head_menu_container);
         menuFlipper = (ViewFlipper) itemView.findViewById(R.id.item_head_menu_flipper);

--- a/app/src/main/java/com/orgzly/android/ui/ViewHolder.java
+++ b/app/src/main/java/com/orgzly/android/ui/ViewHolder.java
@@ -72,7 +72,6 @@ public class ViewHolder /* extends RecyclerView.ViewHolder */ {
         closedText = (TextView) itemView.findViewById(R.id.item_head_closed_text);
 
         content = (TextView) itemView.findViewById(R.id.item_head_content);
-	/* This is where the content widget is set up */
 
         menuContainer = (ViewGroup) itemView.findViewById(R.id.item_head_menu_container);
         menuFlipper = (ViewFlipper) itemView.findViewById(R.id.item_head_menu_flipper);

--- a/app/src/main/res/layout/item_head.xml
+++ b/app/src/main/res/layout/item_head.xml
@@ -193,7 +193,7 @@
                 <!-- Content -->
                 <com.orgzly.android.ui.views.TextViewWithLinks
                     android:id="@+id/item_head_content"
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/item_head_below_title_padding_cozy"
                     tools:text="@string/note_content_sample"


### PR DESCRIPTION
Counter-intuitively, it appears that the Android "wrap_content" is what
you want when you *don't* want the content to be wrapped.  (I think
because it means that the size of the widget is determined by wrapping
around the unwrapped content.)