### PR TITLE
Preset book on new note view from filter query

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/ShareActivityTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ShareActivityTest.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.support.test.rule.ActivityTestRule;
 
 import com.orgzly.R;
+import com.orgzly.android.AppIntent;
 import com.orgzly.android.NotePosition;
 import com.orgzly.android.OrgzlyTest;
 import com.orgzly.android.ui.ShareActivity;
@@ -26,6 +27,7 @@ import static com.orgzly.android.espresso.EspressoUtils.toPortrait;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -36,7 +38,7 @@ public class ShareActivityTest extends OrgzlyTest {
     @Rule
     public ActivityTestRule activityRule = new ActivityTestRule<>(ShareActivity.class, true, false);
 
-    private void startActivityWithIntent(String action, String type, String extraText) {
+    private void startActivityWithIntent(String action, String type, String extraText, String filterQuery) {
         Intent intent = new Intent();
 
         if (action != null) {
@@ -51,12 +53,16 @@ public class ShareActivityTest extends OrgzlyTest {
             intent.putExtra(Intent.EXTRA_TEXT, extraText);
         }
 
+        if (filterQuery != null) {
+            intent.putExtra(AppIntent.EXTRA_FILTER, filterQuery);
+        }
+
         activityRule.launchActivity(intent);
     }
 
     @Test
     public void testDefaultBookRemainsSetAfterRotation() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", null);
         toPortrait(activityRule);
         onData(anything())
                 .inAdapterView(allOf(withId(R.id.activity_share_books_spinner), isDisplayed()))
@@ -74,7 +80,7 @@ public class ShareActivityTest extends OrgzlyTest {
         shelfTestUtils.setupBook("book-one", "");
         shelfTestUtils.setupBook("book-two", "");
         shelfTestUtils.setupBook("book-three", "");
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", null);
         toPortrait(activityRule);
         onView(withId(R.id.activity_share_books_spinner)).perform(click()); // Open spinner
         onView(withText("book-two")).perform(click());
@@ -85,7 +91,7 @@ public class ShareActivityTest extends OrgzlyTest {
 
     @Test
     public void testDefaultBookName() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", null);
 
         onData(anything())
                 .inAdapterView(allOf(withId(R.id.activity_share_books_spinner), isDisplayed()))
@@ -95,13 +101,13 @@ public class ShareActivityTest extends OrgzlyTest {
 
     @Test
     public void testTextSimple() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", null);
         onView(withId(R.id.done)).perform(click());
     }
 
     @Test
     public void testSaveAfterRotation() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", null);
         toLandscape(activityRule);
         toPortrait(activityRule);
         onView(withId(R.id.done)).perform(click());
@@ -109,19 +115,19 @@ public class ShareActivityTest extends OrgzlyTest {
 
     @Test
     public void testTextEmpty() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "", null);
         onView(withId(R.id.done)).perform(click());
     }
 
     @Test
     public void testTextNull() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", null);
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", null, null);
         onView(withId(R.id.done)).perform(click());
     }
 
     @Test
     public void testNoMatchingType() {
-        startActivityWithIntent(Intent.ACTION_SEND, "image/png", null);
+        startActivityWithIntent(Intent.ACTION_SEND, "image/png", null, null);
 
         onView(withId(R.id.fragment_note_title)).check(matches(withText("")));
         onSnackbar().check(matches(withText(context.getString(R.string.share_type_not_supported, "image/png"))));
@@ -129,7 +135,7 @@ public class ShareActivityTest extends OrgzlyTest {
 
     @Test
     public void testNoActionSend() {
-        startActivityWithIntent(null, null, null);
+        startActivityWithIntent(null, null, null, null);
 
         onView(withId(R.id.fragment_note_title)).check(matches(withText("")));
     }
@@ -139,7 +145,7 @@ public class ShareActivityTest extends OrgzlyTest {
     // android.view.WindowLeaked: Activity com.orgzly.android.ui.ShareActivity has leaked window android.widget.PopupWindow$PopupDecorView
     @Test
     public void testSettingStateRemainsSetAfterRotation() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", null);
         toPortrait(activityRule);
         onView(withId(R.id.fragment_note_state)).perform(click()); // Open spinner
         onSpinnerString("TODO").perform(click());
@@ -152,7 +158,7 @@ public class ShareActivityTest extends OrgzlyTest {
 
     @Test
     public void testSettingPriorityRemainsSetAfterRotation() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", null);
         toPortrait(activityRule);
         onView(withId(R.id.fragment_note_priority)).perform(click()); // Open spinner
         onSpinnerString("B").perform(click());
@@ -165,7 +171,7 @@ public class ShareActivityTest extends OrgzlyTest {
 
     @Test
     public void testSettingScheduledTimeRemainsSetAfterRotation() {
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", null);
         toPortrait(activityRule);
         onView(withId(R.id.fragment_note_scheduled_button)).check(matches(withText(R.string.schedule_button_hint)));
         onView(withId(R.id.fragment_note_scheduled_button)).perform(click());
@@ -178,7 +184,7 @@ public class ShareActivityTest extends OrgzlyTest {
     @Test
     public void testNoteInsertedLast() {
         shelfTestUtils.setupBook("book-one", "* Note 1\n** Note 2");
-        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "Note 3");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "Note 3", null);
 
         onView(withId(R.id.done)).perform(click());
 
@@ -191,5 +197,16 @@ public class ShareActivityTest extends OrgzlyTest {
         assertTrue(n2.getRgt() < n1.getRgt());
         assertTrue(n1.getRgt() < n3.getLft());
         assertTrue(n3.getLft() < n3.getRgt());
+    }
+
+    @Test
+    public void testPresetBookFromFilterQuery() {
+        shelfTestUtils.setupBook("foo", "doesn't matter");
+        startActivityWithIntent(Intent.ACTION_SEND, "text/plain", "This is some shared text", "b.foo");
+
+        onData(anything())
+                .inAdapterView(allOf(withId(R.id.activity_share_books_spinner), isDisplayed()))
+                .atPosition(0)
+                .check(matches(withText("foo")));
     }
 }

--- a/app/src/androidTest/java/com/orgzly/android/util/QueryUtilsTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/util/QueryUtilsTest.java
@@ -30,6 +30,7 @@ public class QueryUtilsTest {
         return Arrays.asList(new Object[][]{
                 {"b.foo", "foo"},
                 {"b.foo b.bar", "foo"},
+                {"foo or b.bar", "bar"},
                 {"", null}
         });
     }

--- a/app/src/androidTest/java/com/orgzly/android/util/QueryUtilsTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/util/QueryUtilsTest.java
@@ -1,0 +1,44 @@
+package com.orgzly.android.util;
+
+import android.net.Uri;
+
+import com.orgzly.android.query.Condition;
+import com.orgzly.android.query.Query;
+import com.orgzly.android.query.user.DottedQueryParser;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(value = Parameterized.class)
+public class QueryUtilsTest {
+
+    private final String query;
+    private final String expectedBookName;
+
+    public QueryUtilsTest(String query, String expectedBookName) {
+        this.query = query;
+        this.expectedBookName = expectedBookName;
+    }
+
+    @Parameterized.Parameters(name = "{index}: query {0} should return book name {1}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"b.foo", "foo"},
+                {"b.foo b.bar", "foo"},
+                {"", null}
+        });
+    }
+
+    @Test
+    public void testExtractFirstBookNameFromQuery() throws Exception {
+        Condition condition = new DottedQueryParser().parse(query).getCondition();
+        String result = QueryUtils.extractFirstBookNameFromQuery(condition);
+
+        assertEquals(expectedBookName, result);
+    }
+}

--- a/app/src/main/java/com/orgzly/android/AppIntent.java
+++ b/app/src/main/java/com/orgzly/android/AppIntent.java
@@ -42,4 +42,5 @@ public class AppIntent {
     public static final String EXTRA_CLICK_TYPE = "com.orgzly.intent.extra.CLICK_TYPE";
     public static final String EXTRA_SAVED_SEARCH_ID = "com.orgzly.intent.extra.SAVED_SEARCH_ID";
     public static final String EXTRA_IS_AUTOMATIC = "com.orgzly.intent.extra.IS_AUTOMATIC";
+    public static final String EXTRA_FILTER = "com.orgzly.intent.extra.FILTER";
 }

--- a/app/src/main/java/com/orgzly/android/Notifications.java
+++ b/app/src/main/java/com/orgzly/android/Notifications.java
@@ -33,7 +33,7 @@ public class Notifications {
     public static void createNewNoteNotification(Context context) {
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, context);
 
-        PendingIntent resultPendingIntent = ShareActivity.createNewNoteIntent(context);
+        PendingIntent resultPendingIntent = ShareActivity.createNewNoteIntent(context, null);
 
         /* Build notification */
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context)

--- a/app/src/main/java/com/orgzly/android/ui/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/ShareActivity.java
@@ -143,7 +143,9 @@ public class ShareActivity extends CommonActivity
 
                     if (bookName != null) {
                         Book book = new Shelf(this).getBook(bookName);
-                        data.bookId = book.getId();
+                        if (book != null) {
+                            data.bookId = book.getId();
+                        }
                     }
                 }
 
@@ -215,7 +217,8 @@ public class ShareActivity extends CommonActivity
                     .add(mSyncFragment, SyncFragment.FRAGMENT_TAG)
                     .commit();
 
-            mNoteFragment = NoteFragment.getInstance(true, data.bookId, 0, Place.UNSPECIFIED, data.title, data.content);
+            long fragmentBookId = data.bookId == null ? 0 : data.bookId;
+            mNoteFragment = NoteFragment.getInstance(true, fragmentBookId, 0, Place.UNSPECIFIED, data.title, data.content);
             getSupportFragmentManager()
                     .beginTransaction()
                     .replace(R.id.activity_share_main, mNoteFragment, NoteFragment.FRAGMENT_TAG)
@@ -308,7 +311,7 @@ public class ShareActivity extends CommonActivity
         resultIntent.setType("text/plain");
         resultIntent.putExtra(Intent.EXTRA_TEXT, "");
 
-        if (filter != null) {
+        if (filter != null && filter.getQuery() != null) {
             resultIntent.putExtra(AppIntent.EXTRA_FILTER, filter.getQuery());
         }
 
@@ -433,6 +436,6 @@ public class ShareActivity extends CommonActivity
     private class Data {
         String title;
         String content;
-        Long bookId = 0L;
+        Long bookId = null;
     }
 }

--- a/app/src/main/java/com/orgzly/android/ui/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/ShareActivity.java
@@ -13,16 +13,21 @@ import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import com.orgzly.BuildConfig;
 import com.orgzly.R;
+import com.orgzly.android.AppIntent;
 import com.orgzly.android.Book;
 import com.orgzly.android.Note;
 import com.orgzly.android.NotesBatch;
 import com.orgzly.android.Shelf;
+import com.orgzly.android.filter.Filter;
 import com.orgzly.android.prefs.AppPreferences;
+import com.orgzly.android.query.Query;
+import com.orgzly.android.query.user.DottedQueryParser;
 import com.orgzly.android.ui.fragments.NoteFragment;
 import com.orgzly.android.ui.fragments.SyncFragment;
 import com.orgzly.android.ui.util.ActivityUtils;
 import com.orgzly.android.util.LogUtils;
 import com.orgzly.android.util.MiscUtils;
+import com.orgzly.android.util.QueryUtils;
 import com.orgzly.org.datetime.OrgDateTime;
 
 import java.io.File;
@@ -78,7 +83,7 @@ public class ShareActivity extends CommonActivity
 
         setupBooksSpinner(savedInstanceState);
 
-        setupBooksSpinnerAdapter(savedInstanceState);
+        setupBooksSpinnerAdapter(savedInstanceState, data);
     }
 
     public Data getDataFromIntent(Intent intent) {
@@ -132,6 +137,16 @@ public class ShareActivity extends CommonActivity
                     data.title = intent.getStringExtra(Intent.EXTRA_SUBJECT);
                 }
 
+                if (intent.hasExtra(AppIntent.EXTRA_FILTER)) {
+                    Query query = new DottedQueryParser().parse(intent.getStringExtra(AppIntent.EXTRA_FILTER));
+                    String bookName = QueryUtils.extractFirstBookNameFromQuery(query.getCondition());
+
+                    if (bookName != null) {
+                        Book book = new Shelf(this).getBook(bookName);
+                        data.bookId = book.getId();
+                    }
+                }
+
             } else {
                 mError = getString(R.string.share_type_not_supported, type);
             }
@@ -153,7 +168,7 @@ public class ShareActivity extends CommonActivity
         return data;
     }
 
-    private void setupBooksSpinnerAdapter(final Bundle savedInstanceState) {
+    private void setupBooksSpinnerAdapter(final Bundle savedInstanceState, Data data) {
         new AsyncTask<Void, Void, List<Book>>() {
             @Override
             protected List<Book> doInBackground(Void... params) {
@@ -169,7 +184,14 @@ public class ShareActivity extends CommonActivity
                 mBooksSpinner.setAdapter(adapter);
 
                 if (savedInstanceState != null && savedInstanceState.containsKey(SPINNER_POSITION_KEY)) {
-                    mBooksSpinner.setSelection(savedInstanceState.getInt(SPINNER_POSITION_KEY, 0));
+                    mBooksSpinner.setSelection(savedInstanceState.getInt(SPINNER_POSITION_KEY, 0), false);
+                } else if (data != null && data.bookId != null) {
+                    for (int i = 0; i < books.size(); i++) {
+                        if (books.get(i).getId() == data.bookId) {
+                            mBooksSpinner.setSelection(i);
+                            break;
+                        }
+                    }
                 } else {
                     String defaultBook = AppPreferences.shareNotebook(getApplicationContext());
                     for (int i=0; i<books.size(); i++) {
@@ -193,7 +215,7 @@ public class ShareActivity extends CommonActivity
                     .add(mSyncFragment, SyncFragment.FRAGMENT_TAG)
                     .commit();
 
-            mNoteFragment = NoteFragment.getInstance(true, 0, 0, Place.UNSPECIFIED, data.title, data.content);
+            mNoteFragment = NoteFragment.getInstance(true, data.bookId, 0, Place.UNSPECIFIED, data.title, data.content);
             getSupportFragmentManager()
                     .beginTransaction()
                     .replace(R.id.activity_share_main, mNoteFragment, NoteFragment.FRAGMENT_TAG)
@@ -280,11 +302,15 @@ public class ShareActivity extends CommonActivity
         return books;
     }
 
-    public static PendingIntent createNewNoteIntent(Context context) {
+    public static PendingIntent createNewNoteIntent(Context context, Filter filter) {
         Intent resultIntent = new Intent(context, ShareActivity.class);
         resultIntent.setAction(Intent.ACTION_SEND);
         resultIntent.setType("text/plain");
         resultIntent.putExtra(Intent.EXTRA_TEXT, "");
+
+        if (filter != null) {
+            resultIntent.putExtra(AppIntent.EXTRA_FILTER, filter.getQuery());
+        }
 
         // The stack builder object will contain an artificial back stack for the
         // started Activity.
@@ -407,5 +433,6 @@ public class ShareActivity extends CommonActivity
     private class Data {
         String title;
         String content;
+        Long bookId = 0L;
     }
 }

--- a/app/src/main/java/com/orgzly/android/util/QueryUtils.java
+++ b/app/src/main/java/com/orgzly/android/util/QueryUtils.java
@@ -1,0 +1,29 @@
+package com.orgzly.android.util;
+
+import com.orgzly.android.query.Condition;
+
+public class QueryUtils {
+    public static String extractFirstBookNameFromQuery(Condition condition) {
+        if (condition instanceof Condition.And) {
+            Condition.And c = (Condition.And) condition;
+
+            for (Condition innerCondition : c.getOperands()) {
+                String result = extractFirstBookNameFromQuery(innerCondition);
+
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+
+        if (condition instanceof Condition.InBook) {
+            Condition.InBook c = (Condition.InBook) condition;
+
+            if (!c.getNot()) {
+                return c.getName();
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/src/main/java/com/orgzly/android/util/QueryUtils.java
+++ b/app/src/main/java/com/orgzly/android/util/QueryUtils.java
@@ -16,6 +16,18 @@ public class QueryUtils {
             }
         }
 
+        if (condition instanceof Condition.Or) {
+            Condition.Or c = (Condition.Or) condition;
+
+            for (Condition innerCondition : c.getOperands()) {
+                String result = extractFirstBookNameFromQuery(innerCondition);
+
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+
         if (condition instanceof Condition.InBook) {
             Condition.InBook c = (Condition.InBook) condition;
 

--- a/app/src/main/java/com/orgzly/android/widgets/ListWidgetProvider.java
+++ b/app/src/main/java/com/orgzly/android/widgets/ListWidgetProvider.java
@@ -78,7 +78,7 @@ public class ListWidgetProvider extends AppWidgetProvider {
         remoteViews.setPendingIntentTemplate(R.id.list_widget_list_view, onClickPendingIntent);
 
         // Plus icon - new note
-        remoteViews.setOnClickPendingIntent(R.id.list_widget_header_add, ShareActivity.createNewNoteIntent(context));
+        remoteViews.setOnClickPendingIntent(R.id.list_widget_header_add, ShareActivity.createNewNoteIntent(context, filter));
 
         // Logo - open query
         Intent openIntent = Intent.makeRestartActivityTask(new ComponentName(context, MainActivity.class));


### PR DESCRIPTION
This change implements a convenience feature by selecting the book from the filter defined in current widget view. As filter can get very complex, I've tried to narrow it down to first positive occurrence of a book. While this implementation is far from perfect IMHO this reduces a minor inconvenience and saves a couple of seconds a day.