### PR TITLE
Support plain timestamps

### DIFF
--- a/app/src/main/java/com/orgzly/android/provider/Database.java
+++ b/app/src/main/java/com/orgzly/android/provider/Database.java
@@ -16,6 +16,7 @@ import com.orgzly.android.provider.models.DbCurrentVersionedRook;
 import com.orgzly.android.provider.models.DbDbRepo;
 import com.orgzly.android.provider.models.DbNote;
 import com.orgzly.android.provider.models.DbNoteAncestor;
+import com.orgzly.android.provider.models.DbNoteContentTime;
 import com.orgzly.android.provider.models.DbNoteProperty;
 import com.orgzly.android.provider.models.DbOrgRange;
 import com.orgzly.android.provider.models.DbOrgTimestamp;
@@ -116,6 +117,7 @@ public class Database extends SQLiteOpenHelper {
         for (String sql : DbCurrentVersionedRook.CREATE_SQL) db.execSQL(sql);
         for (String sql : DbDbRepo.CREATE_SQL) db.execSQL(sql);
         for (String sql : DbNoteProperty.CREATE_SQL) db.execSQL(sql);
+        for (String sql : DbNoteContentTime.CREATE_SQL) db.execSQL(sql);
         for (String sql : DbPropertyName.CREATE_SQL) db.execSQL(sql);
         for (String sql : DbPropertyValue.CREATE_SQL) db.execSQL(sql);
         for (String sql : DbProperty.CREATE_SQL) db.execSQL(sql);
@@ -140,6 +142,7 @@ public class Database extends SQLiteOpenHelper {
         db.execSQL(DbCurrentVersionedRook.DROP_SQL);
         db.execSQL(DbDbRepo.DROP_SQL);
         db.execSQL(DbNoteProperty.DROP_SQL);
+        db.execSQL(DbNoteContentTime.DROP_SQL);
         db.execSQL(DbPropertyName.DROP_SQL);
         db.execSQL(DbPropertyValue.DROP_SQL);
         db.execSQL(DbProperty.DROP_SQL);

--- a/app/src/main/java/com/orgzly/android/provider/Provider.java
+++ b/app/src/main/java/com/orgzly/android/provider/Provider.java
@@ -35,6 +35,7 @@ import com.orgzly.android.provider.models.DbCurrentVersionedRook;
 import com.orgzly.android.provider.models.DbDbRepo;
 import com.orgzly.android.provider.models.DbNote;
 import com.orgzly.android.provider.models.DbNoteAncestor;
+import com.orgzly.android.provider.models.DbNoteContentTime;
 import com.orgzly.android.provider.models.DbNoteProperty;
 import com.orgzly.android.provider.models.DbOrgRange;
 import com.orgzly.android.provider.models.DbOrgTimestamp;
@@ -1403,6 +1404,12 @@ public class Provider extends ContentProvider {
                                 long propertyId = DbProperty.getOrInsert(db, nameId, valueId);
 
                                 DbNoteProperty.getOrInsert(db, noteId, pos++, propertyId);
+                            }
+
+                            /* Insert note's content times. */
+                            for (OrgRange time: node.getHead().getContent().getTimestamps()) {
+                                long rangeId = getOrInsertOrgRange(db, time);
+                                DbNoteContentTime.getOrInsert(db, noteId, rangeId);
                             }
 
                             /*

--- a/app/src/main/java/com/orgzly/android/provider/clients/NotesClient.java
+++ b/app/src/main/java/com/orgzly/android/provider/clients/NotesClient.java
@@ -140,8 +140,8 @@ public class NotesClient {
         }
 
         if (head.hasContent()) {
-            values.put(ProviderContract.Notes.UpdateParam.CONTENT, head.getContent());
-            values.put(ProviderContract.Notes.UpdateParam.CONTENT_LINE_COUNT, MiscUtils.lineCount(head.getContent()));
+            values.put(ProviderContract.Notes.UpdateParam.CONTENT, head.getContentString());
+            values.put(ProviderContract.Notes.UpdateParam.CONTENT_LINE_COUNT, MiscUtils.lineCount(head.getContentString()));
         } else {
             values.putNull(ProviderContract.Notes.UpdateParam.CONTENT);
             values.put(ProviderContract.Notes.UpdateParam.CONTENT_LINE_COUNT, 0);

--- a/app/src/main/java/com/orgzly/android/provider/models/DbNote.java
+++ b/app/src/main/java/com/orgzly/android/provider/models/DbNote.java
@@ -106,8 +106,8 @@ public class DbNote implements DbNoteColumns, BaseColumns {
         }
 
         if (head.hasContent()) {
-            values.put(CONTENT, head.getContent());
-            values.put(CONTENT_LINE_COUNT, MiscUtils.lineCount(head.getContent()));
+            values.put(CONTENT, head.getContentString());
+            values.put(CONTENT_LINE_COUNT, MiscUtils.lineCount(head.getContentString()));
         }
     }
 

--- a/app/src/main/java/com/orgzly/android/provider/models/DbNoteContentTime.java
+++ b/app/src/main/java/com/orgzly/android/provider/models/DbNoteContentTime.java
@@ -1,0 +1,47 @@
+package com.orgzly.android.provider.models;
+
+
+import android.content.ContentValues;
+import android.database.sqlite.SQLiteDatabase;
+import android.provider.BaseColumns;
+
+import com.orgzly.android.provider.DatabaseUtils;
+
+public class DbNoteContentTime implements DbNoteContentTimeColumns, BaseColumns {
+    public static final String TABLE = "note_content_times";
+
+    public static final String[] CREATE_SQL = {
+            "CREATE TABLE IF NOT EXISTS " + TABLE + " (" +
+            _ID + " INTEGER PRIMARY KEY AUTOINCREMENT," +
+
+            NOTE_ID + " INTEGER," +
+            TIME_ID + " INTEGER," +
+
+            "UNIQUE(" + NOTE_ID + "," + TIME_ID +"))",
+
+            "CREATE INDEX IF NOT EXISTS i_" + TABLE + "_" + NOTE_ID + " ON " + TABLE + "(" + NOTE_ID + ")",
+            "CREATE INDEX IF NOT EXISTS i_" + TABLE + "_" + TIME_ID + " ON " + TABLE + "(" + TIME_ID + ")",
+    };
+
+    public static final String DROP_SQL = "DROP TABLE IF EXISTS " + TABLE;
+
+    public static long getOrInsert(SQLiteDatabase db, long noteId, long timeId) {
+        long id = DatabaseUtils.getId(
+                db,
+                TABLE,
+                NOTE_ID + " = " + noteId + " AND " +
+                TIME_ID + " = " + timeId,
+                null);
+
+
+        if (id == 0) {
+            ContentValues values = new ContentValues();
+            values.put(NOTE_ID, noteId);
+            values.put(TIME_ID, timeId);
+
+            id = db.insertOrThrow(TABLE, null, values);
+        }
+
+        return id;
+    }
+}

--- a/app/src/main/java/com/orgzly/android/provider/models/DbNoteContentTimeColumns.java
+++ b/app/src/main/java/com/orgzly/android/provider/models/DbNoteContentTimeColumns.java
@@ -1,0 +1,6 @@
+package com.orgzly.android.provider.models;
+
+public interface DbNoteContentTimeColumns {
+    String NOTE_ID = "note_id";
+    String TIME_ID = "time_id";
+}

--- a/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
+++ b/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
@@ -190,7 +190,7 @@ public class HeadsListViewAdapter extends SimpleCursorAdapter {
                 holder.content.setTypeface(Typeface.MONOSPACE);
             }
 
-            holder.content.setText(OrgFormatter.INSTANCE.parse(context, head.getContent()));
+            holder.content.setText(OrgFormatter.INSTANCE.parse(context, head.getContentString()));
 
             holder.content.setVisibility(View.VISIBLE);
 
@@ -345,4 +345,3 @@ public class HeadsListViewAdapter extends SimpleCursorAdapter {
         }
     }
 }
-

--- a/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
+++ b/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
@@ -417,7 +417,7 @@ public class NoteFragment extends Fragment
             outState.remove(ARG_CURRENT_PROPERTIES);
         }
 
-        outState.putString(ARG_CURRENT_CONTENT, head.getContent());
+        outState.putString(ARG_CURRENT_CONTENT, head.getContentString());
     }
 
     /**
@@ -502,8 +502,8 @@ public class NoteFragment extends Fragment
         }
 
         /* Content. */
-        bodyEdit.setText(head.getContent());
-        bodyView.setText(OrgFormatter.INSTANCE.parse(getContext(), head.getContent()));
+        bodyEdit.setText(head.getContentString());
+        bodyView.setText(OrgFormatter.INSTANCE.parse(getContext(), head.getContentString()));
     }
 
     private void addPropertyToList(OrgProperty property) {


### PR DESCRIPTION
This is a work in progress for fixing #76.

I've added a new relationship `note_content_times` and modified `Provider.loadBookFromReader` to populate the table.

I guess the next step is to update this table whenever the content changes, and to cleanup when the note is destroyed.

Then, we should be able to lookup in this table for agenda searches and reminders.

Am I on the right track?  Don't be afraid to tell me if not. :)