### PR TITLE
Show sync action in app bar if there's room

### DIFF
--- a/app/src/main/res/menu/activity_actions.xml
+++ b/app/src/main/res/menu/activity_actions.xml
@@ -25,7 +25,8 @@
 
     <item
         android:id="@+id/activity_action_sync"
-        app:showAsAction="never"
+        android:icon="?attr/ic_sync_24dp"
+        app:showAsAction="ifRoom"
         android:orderInCategory="10"
         android:title="@string/sync"/>
 


### PR DESCRIPTION
Syncing is the most common action that I perform from the app bar.  If there's space, show Sync in the app bar instead of the overflow menu.