### PR TITLE
Add possibility to check/uncheck checkboxes

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
+++ b/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
@@ -225,6 +225,17 @@ public class HeadsListViewAdapter extends SimpleCursorAdapter {
                     // TODO: How to update the note without causing a recursion?
                     //NotesClient.update(context, note);
                     holder.content.addTextChangedListener(this);
+
+                    // Consider doing this?
+                    /*
+                    if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, "Text modified in list", s);
+                    ActionService.Companion.enqueueWork(
+                            context,
+                            new Intent(context, ActionService.class)
+                                    .setAction(AppIntent.ACTION_UPDATE_NOTE)
+                                    .putExtra(AppIntent.EXTRA_NOTE_CONTENT, s.toString()));
+                                        */
+
                 }
             });
 

--- a/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
+++ b/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
@@ -8,6 +8,8 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.support.v4.widget.SimpleCursorAdapter;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
@@ -205,6 +207,23 @@ public class HeadsListViewAdapter extends SimpleCursorAdapter {
             }
 
             holder.content.setRawText(head.getContent());
+            holder.content.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                }
+
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                }
+
+                @Override
+                public void afterTextChanged(Editable s) {
+                    // Update note when checkboxes are clicked
+                    head.setContent(s.toString());
+                    note.setHead(head);
+                    NotesClient.update(context, note);
+                }
+            });
 
             holder.content.setVisibility(View.VISIBLE);
 

--- a/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
+++ b/app/src/main/java/com/orgzly/android/ui/HeadsListViewAdapter.java
@@ -219,9 +219,12 @@ public class HeadsListViewAdapter extends SimpleCursorAdapter {
                 @Override
                 public void afterTextChanged(Editable s) {
                     // Update note when checkboxes are clicked
-                    head.setContent(s.toString());
+                    holder.content.removeTextChangedListener(this);
+                    head.setContent(holder.content.getRawText().toString());
                     note.setHead(head);
-                    NotesClient.update(context, note);
+                    // TODO: How to update the note without causing a recursion?
+                    //NotesClient.update(context, note);
+                    holder.content.addTextChangedListener(this);
                 }
             });
 

--- a/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
+++ b/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
@@ -62,6 +62,8 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Note editor.
@@ -305,7 +307,43 @@ public class NoteFragment extends Fragment
 
         bodyEdit = top.findViewById(R.id.body_edit);
 
+        bodyEdit.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                bodyEdit.removeTextChangedListener(this);
+                Matcher matcher = Pattern.compile("(\n|^)[Cc] ").matcher(s);
+                while(matcher.find()) {
+                    s.replace(matcher.start(), matcher.end(), matcher.group(1) + "[ ] ");
+                }
+                bodyEdit.addTextChangedListener(this);
+            }
+        });
+
         bodyView = top.findViewById(R.id.body_view);
+
+        bodyView.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                // Update bodyEdit text when checkboxes are clicked
+                bodyEdit.setText(s.toString());
+            }
+        });
 
 //        bodyView.setOnTouchListener(new View.OnTouchListener() {
 //            @Override

--- a/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
+++ b/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
@@ -341,7 +341,8 @@ public class NoteFragment extends Fragment
             @Override
             public void afterTextChanged(Editable s) {
                 // Update bodyEdit text when checkboxes are clicked
-                bodyEdit.setText(s.toString());
+                CharSequence text = bodyView.getRawText();
+                bodyEdit.setText(text);
             }
         });
 

--- a/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
+++ b/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
@@ -19,6 +19,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.MultiAutoCompleteTextView;
@@ -137,6 +138,7 @@ public class NoteFragment extends Fragment
     private LinearLayout propertyList;
 
     private ToggleButton editSwitch;
+    private Button checkboxButton;
     private EditText bodyEdit;
     private TextViewWithMarkup bodyView;
 
@@ -365,6 +367,8 @@ public class NoteFragment extends Fragment
             bodyView.setTypeface(Typeface.MONOSPACE);
         }
 
+        checkboxButton = top.findViewById(R.id.insert_checkbox_button);
+
         editSwitch = top.findViewById(R.id.edit_content_toggle);
 
         editSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
@@ -374,9 +378,11 @@ public class NoteFragment extends Fragment
                 bodyView.setVisibility(View.GONE);
 
                 bodyEdit.setVisibility(View.VISIBLE);
+                checkboxButton.setVisibility(View.VISIBLE);
 
             } else {
                 bodyEdit.setVisibility(View.GONE);
+                checkboxButton.setVisibility(View.GONE);
 
                 bodyView.setRawText(bodyEdit.getText());
                 bodyView.setVisibility(View.VISIBLE);
@@ -393,6 +399,10 @@ public class NoteFragment extends Fragment
             }
         });
 
+        checkboxButton.setOnClickListener(view -> {
+            int sel = bodyEdit.getSelectionStart();
+            bodyEdit.getText().replace(sel, sel, "\n- [ ]");
+        });
 
         mViewFlipper = top.findViewById(R.id.fragment_note_view_flipper);
 

--- a/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
+++ b/app/src/main/java/com/orgzly/android/ui/fragments/NoteFragment.java
@@ -318,6 +318,7 @@ public class NoteFragment extends Fragment
 
             @Override
             public void afterTextChanged(Editable s) {
+                // TODO: Don't do this replacement?
                 bodyEdit.removeTextChangedListener(this);
                 Matcher matcher = Pattern.compile("(\n|^)[Cc] ").matcher(s);
                 while(matcher.find()) {
@@ -345,21 +346,6 @@ public class NoteFragment extends Fragment
                 bodyEdit.setText(text);
             }
         });
-
-//        bodyView.setOnTouchListener(new View.OnTouchListener() {
-//            @Override
-//            public boolean onTouch(View v, MotionEvent event) {
-//                editMode(true, true);
-//                return false;
-//            }
-//        });
-
-//        bodyView.setOnClickListener(new View.OnClickListener() {
-//            @Override
-//            public void onClick(View v) {
-//                editMode(true, true);
-//            }
-//        });
 
         if (getActivity() != null && AppPreferences.isFontMonospaced(getContext())) {
             bodyEdit.setTypeface(Typeface.MONOSPACE);

--- a/app/src/main/java/com/orgzly/android/ui/views/TextViewWithMarkup.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/TextViewWithMarkup.kt
@@ -12,6 +12,7 @@ import com.orgzly.android.ActionService
 import com.orgzly.android.AppIntent
 import com.orgzly.android.ui.views.style.DrawerEndSpan
 import com.orgzly.android.ui.views.style.DrawerSpan
+import com.orgzly.android.ui.views.style.CheckboxSpan
 import com.orgzly.android.util.OrgFormatter
 
 /**
@@ -73,6 +74,29 @@ class TextViewWithMarkup : TextViewFixed {
         text = builder
     }
 
+    fun toggleCheckbox(checkboxSpan: CheckboxSpan) {
+        val textSpanned = text as Spanned
+
+        val checkboxStart = textSpanned.getSpanStart(checkboxSpan)
+        val checkboxEnd = textSpanned.getSpanEnd(checkboxSpan)
+
+        val builder = SpannableStringBuilder(text)
+
+        var oldContent = checkboxSpan.content
+        var check = "X"
+        if (checkboxSpan.isChecked()) {
+            check = " "
+        }
+        var content = (oldContent.substring(0, 1) + check
+                + oldContent.substring(2, oldContent.length))
+        val replacement = checkboxSpanned(content)
+
+        builder.removeSpan(checkboxSpan)
+        builder.replace(checkboxStart, checkboxEnd, replacement)
+
+        text = builder
+    }
+
     companion object {
         fun drawerSpanned(name: String, content: CharSequence, isFolded: Boolean): Spanned {
 
@@ -104,6 +128,21 @@ class TextViewWithMarkup : TextViewFixed {
 
                 builder.append("\n").append(endSpannable)
             }
+
+            return builder
+        }
+
+        fun checkboxSpanned(content: CharSequence): Spanned {
+
+            val builder = SpannableStringBuilder()
+
+            val beginSpannable = SpannableString(content)
+            beginSpannable.setSpan(
+                    CheckboxSpan(content),
+                    0,
+                    beginSpannable.length,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            builder.append(beginSpannable)
 
             return builder
         }

--- a/app/src/main/java/com/orgzly/android/ui/views/TextViewWithMarkup.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/TextViewWithMarkup.kt
@@ -17,6 +17,8 @@ import com.orgzly.android.util.OrgFormatter
 
 /**
  * [TextView] with markup support.
+ *
+ * Used for title, content and preface text.
  */
 class TextViewWithMarkup : TextViewFixed {
     constructor(context: Context) : super(context)

--- a/app/src/main/java/com/orgzly/android/ui/views/TextViewWithMarkup.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/TextViewWithMarkup.kt
@@ -32,6 +32,10 @@ class TextViewWithMarkup : TextViewFixed {
         setText(OrgFormatter.parse(text.toString(), context))
     }
 
+    fun getRawText() : CharSequence? {
+        return rawText
+    }
+
     fun openNoteWithProperty(name: String, value: String) {
         val intent = Intent(context, ActionService::class.java)
         intent.action = AppIntent.ACTION_OPEN_NOTE
@@ -89,12 +93,14 @@ class TextViewWithMarkup : TextViewFixed {
         }
         var content = (oldContent.substring(0, 1) + check
                 + oldContent.substring(2, oldContent.length))
-        val replacement = checkboxSpanned(content)
+        val replacement = checkboxSpanned(content, checkboxSpan.rawStart, checkboxSpan.rawEnd)
 
         builder.removeSpan(checkboxSpan)
         builder.replace(checkboxStart, checkboxEnd, replacement)
 
-        text = builder
+        var newRawText = rawText as CharSequence
+        newRawText = newRawText.replaceRange(checkboxSpan.rawStart, checkboxSpan.rawEnd, replacement)
+        setRawText(newRawText)
     }
 
     companion object {
@@ -132,13 +138,13 @@ class TextViewWithMarkup : TextViewFixed {
             return builder
         }
 
-        fun checkboxSpanned(content: CharSequence): Spanned {
+        fun checkboxSpanned(content: CharSequence, rawStart: Int, rawEnd: Int): Spanned {
 
             val builder = SpannableStringBuilder()
 
             val beginSpannable = SpannableString(content)
             beginSpannable.setSpan(
-                    CheckboxSpan(content),
+                    CheckboxSpan(content, rawStart, rawEnd),
                     0,
                     beginSpannable.length,
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
@@ -19,11 +19,12 @@ class CheckboxSpan(val content: CharSequence, val rawStart: Int, val rawEnd: Int
     }
 
     override fun updateDrawState(tp: TextPaint) {
-        if(isChecked())
+        /*if(isChecked())
             tp.color = Color.GREEN
         else
-            tp.color = Color.RED
+            tp.color = Color.RED*/
         typeface.updateDrawState(tp)
+        tp.isUnderlineText = true
     }
 
     fun isChecked(): Boolean {

--- a/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
@@ -6,10 +6,9 @@ import android.text.TextPaint
 import android.text.style.ClickableSpan
 import android.text.style.TypefaceSpan
 import android.view.View
-import com.orgzly.R
 import com.orgzly.android.ui.views.TextViewWithMarkup
 
-class CheckboxSpan(val content: CharSequence) : ClickableSpan() {
+class CheckboxSpan(val content: CharSequence, val rawStart: Int, val rawEnd: Int) : ClickableSpan() {
 
     private val typeface = TypefaceSpan("monospace")
 

--- a/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
@@ -1,6 +1,5 @@
 package com.orgzly.android.ui.views.style
 
-import android.content.Context
 import android.graphics.Color
 import android.text.TextPaint
 import android.text.style.ClickableSpan
@@ -19,10 +18,10 @@ class CheckboxSpan(val content: CharSequence, val rawStart: Int, val rawEnd: Int
     }
 
     override fun updateDrawState(tp: TextPaint) {
-        /*if(isChecked())
+        if(isChecked())
             tp.color = Color.GREEN
         else
-            tp.color = Color.RED*/
+            tp.color = Color.RED
         typeface.updateDrawState(tp)
         tp.isUnderlineText = true
     }

--- a/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
@@ -1,0 +1,34 @@
+package com.orgzly.android.ui.views.style
+
+import android.content.Context
+import android.graphics.Color
+import android.text.TextPaint
+import android.text.style.ClickableSpan
+import android.text.style.TypefaceSpan
+import android.view.View
+import com.orgzly.R
+import com.orgzly.android.ui.views.TextViewWithMarkup
+
+class CheckboxSpan(val content: CharSequence) : ClickableSpan() {
+
+    private val typeface = TypefaceSpan("monospace")
+
+    override fun onClick(widget: View) {
+        if (widget is TextViewWithMarkup) {
+            widget.toggleCheckbox(this)
+        }
+    }
+
+    override fun updateDrawState(tp: TextPaint) {
+        if(isChecked())
+            tp.color = Color.GREEN
+        else
+            tp.color = Color.RED
+        typeface.updateDrawState(tp)
+    }
+
+    fun isChecked(): Boolean {
+        return content[1] != ' '
+    }
+
+}

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -316,7 +316,7 @@ object OrgFormatter {
 
         while (m.find()) {
             val content = m.group(1)
-            ssb.setSpan(CheckboxSpan(content), m.start(), m.end(), FLAGS)
+            ssb.setSpan(CheckboxSpan(content, m.start(), m.end()), m.start(), m.end(), FLAGS)
         }
     }
 

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -10,6 +10,7 @@ import android.view.View
 import com.orgzly.BuildConfig
 import com.orgzly.android.prefs.AppPreferences
 import com.orgzly.android.ui.views.TextViewWithMarkup
+import com.orgzly.android.ui.views.style.CheckboxSpan
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -47,6 +48,8 @@ object OrgFormatter {
     private val MARKUP_PATTERN = Pattern.compile(
             "(?:^|\\G|[$PRE])(([$MARKUP_CHARS])($BORDER|$BORDER$BODY$BORDER)\\2)(?:[$POST]|$)",
             Pattern.MULTILINE)
+
+    const val CHECKBOX = "(\\[([ Xx])\\][ \n])"
 
     const val LAST_REPEAT_PROPERTY = "LAST_REPEAT"
 
@@ -97,6 +100,8 @@ object OrgFormatter {
         ssb = parseOrgLinks(ssb, BRACKET_LINK, config.linkify)
 
         parsePlainLinks(ssb, PLAIN_LINK, config.linkify)
+
+        parseCheckboxes(ssb)
 
         ssb = parseMarkup(ssb, config)
 
@@ -300,6 +305,19 @@ object OrgFormatter {
         }
 
         return buildFromRegions(ssb, spanRegions)
+    }
+
+    /**
+     * Parse checkboxes and add CheckboxSpans to ssb
+     */
+    private fun parseCheckboxes(ssb: SpannableStringBuilder) {
+        val p = Pattern.compile(CHECKBOX)
+        val m = p.matcher(ssb)
+
+        while (m.find()) {
+            val content = m.group(1)
+            ssb.setSpan(CheckboxSpan(content), m.start(), m.end(), FLAGS)
+        }
     }
 
     private fun parseDrawers(ssb: SpannableStringBuilder, foldDrawers: Boolean): SpannableStringBuilder {

--- a/app/src/main/res/layout/fragment_note.xml
+++ b/app/src/main/res/layout/fragment_note.xml
@@ -197,6 +197,15 @@
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textOn="@string/note_content_finish_editing"
                     android:textOff="@string/note_content_start_editing"/>
+                <Button
+                    android:id="@+id/insert_checkbox_button"
+                    android:layout_marginLeft="30dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="- [ ]"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:visibility="gone"
+                    style="@style/BorderlessButton"/>
             </LinearLayout>
 
             <EditText

--- a/app/src/main/res/raw/orgzly_getting_started.org
+++ b/app/src/main/res/raw/orgzly_getting_started.org
@@ -47,10 +47,11 @@ Send email to [[mailto:support@orgzly.com][support@orgzly.com]], visit http://ww
 
 You can make words *bold*, /italic/, _underlined_, =verbatim=, ~code~ and +strike-through+.
 
-** Checkboxes are supported
+** Checkboxes in lists are supported
 - [X] Task 1
 - [ ] Task 2
 Click the checkbox to check/uncheck it.
+Press enter on the end of the line to add a new checkbox line.
 
 * Search
 ** There are many search operators supported

--- a/app/src/main/res/raw/orgzly_getting_started.org
+++ b/app/src/main/res/raw/orgzly_getting_started.org
@@ -47,6 +47,11 @@ Send email to [[mailto:support@orgzly.com][support@orgzly.com]], visit http://ww
 
 You can make words *bold*, /italic/, _underlined_, =verbatim=, ~code~ and +strike-through+.
 
+** Checkboxes are supported
+[X] This is checked
+[ ] This is not
+Click the checkbox to check/uncheck it.
+
 * Search
 ** There are many search operators supported
 

--- a/app/src/main/res/raw/orgzly_getting_started.org
+++ b/app/src/main/res/raw/orgzly_getting_started.org
@@ -48,8 +48,8 @@ Send email to [[mailto:support@orgzly.com][support@orgzly.com]], visit http://ww
 You can make words *bold*, /italic/, _underlined_, =verbatim=, ~code~ and +strike-through+.
 
 ** Checkboxes are supported
-[X] This is checked
-[ ] This is not
+- [X] Task 1
+- [ ] Task 2
 Click the checkbox to check/uncheck it.
 
 * Search


### PR DESCRIPTION
Issue #58 

This is a suggested implementation of checkboxes, which probably needs some polishing before merging. I'm creating the pull request to get some feedback/advice for (possibly) improving the implementation.

The checkboxes work as follows:
- When you edit the content of a note, "c " at the beginning of a line is automatically replaced by "[ ] ". This is to make it easier to write checkboxes (easier than writing brackets).
- When you view a note, the checkboxes are shown in monospace font, green if "[X]" and red if "[ ]".
- Checkboxes can be checked/unchecked by clicking them.
- It seems that some other formatting (bold etc.) is lost as it is now. I need to fix this.

Possible improvements:
- Using the same exact color for checkboxes as for TODO/DONE
- Using a proper Android Checkbox when viewing the checkbox?
- Using a different trigger for replacement than "c "?
- An option to turn on/off the trigger text, or even edit it?
- Add a checkbox example to the "Getting Started with Orgzly" notebook