### PR TITLE
Add "quick reply" to notification as a way to add new notes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -165,6 +165,8 @@
         <receiver
             android:name=".android.NotificationBroadcastReceiver"/>
 
+        <receiver android:name=".android.NewNoteBroadcastReceiver"/>
+
         <receiver
             android:name=".android.ActionReceiver"
             android:exported="true"

--- a/app/src/main/java/com/orgzly/android/BookUtils.java
+++ b/app/src/main/java/com/orgzly/android/BookUtils.java
@@ -7,6 +7,10 @@ import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 
 import com.orgzly.R;
+import com.orgzly.android.prefs.AppPreferences;
+
+import java.io.IOException;
+import java.util.List;
 
 public class BookUtils {
     /**
@@ -63,5 +67,26 @@ public class BookUtils {
         }
 
         return str;
+    }
+
+    /**
+     * Returns default book if it exists, or first one found.
+     * If there are no books, default book will be created.
+     */
+    public static Book getTargetBook(Context context) throws IOException {
+        Shelf shelf = new Shelf(context);
+        List<Book> books = shelf.getBooks();
+        String defaultBookName = AppPreferences.shareNotebook(context);
+
+        if (books.size() == 0) {
+            return shelf.createBook(defaultBookName);
+        } else {
+            for (Book book : books) {
+                if (defaultBookName.equals(book.getName())) {
+                    return book;
+                }
+            }
+            return books.get(0);
+        }
     }
 }

--- a/app/src/main/java/com/orgzly/android/NewNoteBroadcastReceiver.java
+++ b/app/src/main/java/com/orgzly/android/NewNoteBroadcastReceiver.java
@@ -1,0 +1,47 @@
+package com.orgzly.android;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.RemoteInput;
+
+import com.orgzly.android.prefs.AppPreferences;
+import com.orgzly.android.provider.clients.NotesClient;
+import com.orgzly.org.OrgHead;
+
+import java.io.IOException;
+
+public class NewNoteBroadcastReceiver extends BroadcastReceiver {
+    public static final String NOTE_TITLE = "NOTE_TITLE";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String title = getNoteTitle(intent);
+        if (title != null) {
+            try {
+                Book targetBook = BookUtils.getTargetBook(context);
+                NotesClient.create(context, makeNote(AppPreferences.newNoteState(context), title, targetBook));
+                Notifications.createNewNoteNotification(context);
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    private Note makeNote(String state, String title, Book targetBook) {
+        OrgHead head = new OrgHead();
+        head.setTitle(title);
+        head.setState(state);
+        Note note = new Note();
+        note.setCreatedAt(System.currentTimeMillis());
+        note.getPosition().setBookId(targetBook.getId());
+        note.setHead(head);
+        return note;
+    }
+
+    private String getNoteTitle(Intent intent) {
+        Bundle remoteInput = RemoteInput.getResultsFromIntent(intent);
+        return remoteInput == null ? null : remoteInput.getString(NOTE_TITLE);
+    }
+}

--- a/app/src/main/java/com/orgzly/android/Notifications.java
+++ b/app/src/main/java/com/orgzly/android/Notifications.java
@@ -7,7 +7,9 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.RemoteInput;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import com.orgzly.BuildConfig;
@@ -20,6 +22,8 @@ import com.orgzly.android.ui.ShareActivity;
 import com.orgzly.android.util.LogUtils;
 
 import java.util.List;
+
+import static com.orgzly.android.NewNoteBroadcastReceiver.NOTE_TITLE;
 
 public class Notifications {
     public static final String TAG = Notifications.class.getName();
@@ -44,6 +48,22 @@ public class Notifications {
                 .setColor(ContextCompat.getColor(context, R.color.notification))
                 .setContentIntent(resultPendingIntent)
                 .setPriority(NotificationCompat.PRIORITY_MIN); // Don't show icon on status bar
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            PendingIntent newNotePendingIntent = PendingIntent.getBroadcast(
+                    context, 0, new Intent(context, NewNoteBroadcastReceiver.class), 0);
+
+            RemoteInput remoteInput = new RemoteInput.Builder(NOTE_TITLE)
+                    .setLabel(context.getString(R.string.quick_note))
+                    .build();
+
+            /* Add new note action */
+            NotificationCompat.Action action = new NotificationCompat.Action.Builder(
+                    R.drawable.ic_add_white_24dp, context.getString(R.string.quick_note), newNotePendingIntent)
+                    .addRemoteInput(remoteInput)
+                    .build();
+            builder.addAction(action);
+        }
 
         /* Add open action */
         PendingIntent openAppPendingIntent = PendingIntent.getActivity(

--- a/app/src/main/java/com/orgzly/android/provider/clients/NotesClient.java
+++ b/app/src/main/java/com/orgzly/android/provider/clients/NotesClient.java
@@ -308,6 +308,9 @@ public class NotesClient {
         return result[0].count;
     }
 
+    public static Note create(Context context, Note note) {
+        return create(context, note, null, note.getCreatedAt());
+    }
 
     /**
      * Insert as last note if position is not specified.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="heads_moving_action_menu_item_up">Up</string>
     <string name="heads_moving_action_menu_item_demote">Demote</string>
     <string name="new_note">New note</string>
+    <string name="quick_note">Quick note</string>
     <string name="tap_to_create_new_note">Tap to create a new note</string>
     <string name="options_menu_item_search">Search</string>
 


### PR DESCRIPTION
When entering notes I want to be able to quickly write something and store it away to deal with later. At the moment this involves me opening a screen with lots of fields, filling in the one field I care about (the title), then saving the note. I would much rather use the "quick reply" feature on the notification to be able to enter a note, without interrupting what I am currently doing. This is similar to the way I use `org-capture`.

This PR contains code to implement this. I'm not _completely_ happy with it, but I like to start a conversation with a proof of concept. I'm not familiar with how Orgzly works, so it's likely that I have not done this the right way.