### PR TITLE
Handle "file:" links for opening files on android storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -144,6 +144,16 @@
             android:authorities="com.orgzly">
         </provider>
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="com.orgzly.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <receiver
             android:name="com.orgzly.android.widgets.ListWidgetProvider"
             android:label="@string/list_widget_name">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -146,7 +146,7 @@
 
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="com.orgzly.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/java/com/orgzly/android/App.java
+++ b/app/src/main/java/com/orgzly/android/App.java
@@ -7,6 +7,8 @@ import android.support.multidex.MultiDexApplication;
 
 import com.evernote.android.job.JobConfig;
 import com.evernote.android.job.JobManager;
+import com.orgzly.android.ui.CommonActivity;
+import com.orgzly.android.ui.CommonActivityLifecycleCallbacks;
 import com.orgzly.android.ui.settings.SettingsFragment;
 
 /**
@@ -24,9 +26,14 @@ public class App extends MultiDexApplication {
     public static final AppExecutors EXECUTORS = new AppExecutors();
 
     private static Context context;
+    private static CommonActivity currentActivity;
 
     @Override
     public void onCreate() {
+        // Register CommonActivity life cycle within the App
+        // to be able to access the activity in classes like OrgFormatter
+        registerActivityLifecycleCallbacks(new CommonActivityLifecycleCallbacks());
+
         super.onCreate();
 
         App.setDefaultPreferences(this, false);
@@ -48,5 +55,14 @@ public class App extends MultiDexApplication {
 
     public static Context getAppContext() {
         return App.context;
+    }
+
+    // Getter/setter for the current activity
+    public static void setCurrentActivity(CommonActivity currentCommonActivity) {
+        currentActivity = currentCommonActivity;
+    }
+
+    public static CommonActivity getCurrentActivity() {
+        return currentActivity;
     }
 }

--- a/app/src/main/java/com/orgzly/android/App.java
+++ b/app/src/main/java/com/orgzly/android/App.java
@@ -4,7 +4,6 @@ package com.orgzly.android;
 import android.content.Context;
 import android.preference.PreferenceManager;
 import android.support.multidex.MultiDexApplication;
-import android.content.Context;
 
 import com.evernote.android.job.JobConfig;
 import com.evernote.android.job.JobManager;

--- a/app/src/main/java/com/orgzly/android/ui/CommonActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/CommonActivity.kt
@@ -148,8 +148,12 @@ abstract class CommonActivity : AppCompatActivity() {
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
         val consumed = super.dispatchTouchEvent(ev)
 
-        if (ev.action == MotionEvent.ACTION_UP) {
-            dismissSnackbar()
+        if (ev.action == MotionEvent.ACTION_DOWN) {
+            snackbar?.let {
+            if (it.isShown()) {
+                    dismissSnackbar()
+                }
+            }
         }
 
         return consumed

--- a/app/src/main/java/com/orgzly/android/ui/CommonActivityLifecycleCallbacks.java
+++ b/app/src/main/java/com/orgzly/android/ui/CommonActivityLifecycleCallbacks.java
@@ -22,12 +22,12 @@ public class CommonActivityLifecycleCallbacks  implements Application.ActivityLi
 
     @Override
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-        registerActivity(activity);
+        registerActivity(null);
     }
 
     @Override
     public void onActivityStarted(Activity activity) {
-        registerActivity(activity);
+        registerActivity(null);
     }
 
     @Override

--- a/app/src/main/java/com/orgzly/android/ui/CommonActivityLifecycleCallbacks.java
+++ b/app/src/main/java/com/orgzly/android/ui/CommonActivityLifecycleCallbacks.java
@@ -1,0 +1,57 @@
+package com.orgzly.android.ui;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+
+import com.orgzly.android.App;
+
+// Monitor the lifecycle of CommonActivity
+// This allows to access the activity in files like OrgFormatter
+// and enables permission and snackbar access
+public class CommonActivityLifecycleCallbacks  implements Application.ActivityLifecycleCallbacks {
+
+    public void registerActivity(Activity activity)
+    {
+        if (activity instanceof CommonActivity) {
+            App.setCurrentActivity((CommonActivity) activity);
+        } else {
+            App.setCurrentActivity(null);
+        }
+    }
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        registerActivity(activity);
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+        registerActivity(activity);
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        registerActivity(activity);
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+        registerActivity(null);
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        registerActivity(null);
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+        registerActivity(null);
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+        registerActivity(null);
+    }
+}

--- a/app/src/main/java/com/orgzly/android/util/AppPermissions.kt
+++ b/app/src/main/java/com/orgzly/android/util/AppPermissions.kt
@@ -51,6 +51,7 @@ object AppPermissions {
             Usage.BOOK_EXPORT -> Manifest.permission.WRITE_EXTERNAL_STORAGE
             Usage.SYNC_START -> Manifest.permission.WRITE_EXTERNAL_STORAGE
             Usage.FILTERS_EXPORT_IMPORT -> Manifest.permission.WRITE_EXTERNAL_STORAGE
+            Usage.EXTERNAL_FILES_ACCESS -> Manifest.permission.READ_EXTERNAL_STORAGE
         }
     }
 
@@ -61,6 +62,7 @@ object AppPermissions {
             Usage.BOOK_EXPORT -> R.string.permissions_rationale_for_book_export
             Usage.SYNC_START -> R.string.permissions_rationale_for_sync_start
             Usage.FILTERS_EXPORT_IMPORT -> R.string.storage_permissions_missing
+            Usage.EXTERNAL_FILES_ACCESS -> R.string.permissions_rationale_for_external_files_access
         }
     }
 
@@ -68,6 +70,7 @@ object AppPermissions {
         LOCAL_REPO,
         BOOK_EXPORT,
         SYNC_START,
-        FILTERS_EXPORT_IMPORT
+        FILTERS_EXPORT_IMPORT,
+        EXTERNAL_FILES_ACCESS
     }
 }

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -370,37 +370,36 @@ object OrgFormatter {
                     override fun onClick(widget: View?) {
                         val context = App.getAppContext()
 
-                        // Check that we have the permission to read external files
-                        val isGranted = AppPermissions.isGranted(context, AppPermissions.Usage.EXTERNAL_FILES_ACCESS)
+                        // Get the current activity is available
+                        val currentActivity = App.getCurrentActivity()
+                        if(currentActivity != null) {
+                            // Check that we have the permission to read external files
+                            // or ask for it
+                            val isGranted = AppPermissions.isGrantedOrRequest(currentActivity, AppPermissions.Usage.EXTERNAL_FILES_ACCESS)
 
-                        if (isGranted) {
-                            // Get the file
-                            val file = File(Environment.getExternalStorageDirectory(), s[1])
+                            if (isGranted) {
+                                // Get the file
+                                val file = File(Environment.getExternalStorageDirectory(), s[1])
 
-                            // Check file existence, before trying to process it
-                            if(file.exists()) {
-                                val contentUri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileprovider", file)
+                                // Check file existence, before trying to process it
+                                if (file.exists()) {
+                                    val contentUri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileprovider", file)
 
-                                val intent = Intent(Intent.ACTION_VIEW, contentUri)
-                                // Added for support on API 16
-                                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                    val intent = Intent(Intent.ACTION_VIEW, contentUri)
+                                    // Added for support on API 16
+                                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
-                                // Try to start an activity for opening the file
-                                try {
-                                    startActivity(context, intent, null)
-                                } catch (e: ActivityNotFoundException) {
-                                    Toast.makeText(context, R.string.external_file_no_app_found, Toast.LENGTH_SHORT).show()
+                                    // Try to start an activity for opening the file
+                                    try {
+                                        startActivity(context, intent, null)
+                                    } catch (e: ActivityNotFoundException) {
+                                        currentActivity.showSnackbar(R.string.external_file_no_app_found)
+                                    }
+                                } else {
+                                    currentActivity.showSnackbar(String.format(context.getString(R.string.external_file_not_found), file.absolutePath))
                                 }
                             }
-                            else
-                            {
-                                Toast.makeText(context, String.format(context.getString(R.string.external_file_not_found), file.absolutePath), Toast.LENGTH_SHORT).show()
-                            }
-                        }
-                        else
-                        {
-                            Toast.makeText(context, R.string.permissions_rationale_for_external_files_access, Toast.LENGTH_SHORT).show()
                         }
                     }
                 }

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -372,12 +372,12 @@ object OrgFormatter {
 
                         // Get the current activity is available
                         val currentActivity = App.getCurrentActivity()
-                        if(currentActivity != null) {
-                            // Check that we have the permission to read external files
-                            // or ask for it
-                            val isGranted = AppPermissions.isGrantedOrRequest(currentActivity, AppPermissions.Usage.EXTERNAL_FILES_ACCESS)
 
-                            if (isGranted) {
+                        // Check that we have the permission to read external files
+                        // or ask for it and run the associated code
+                        currentActivity?.runWithPermission(
+                            AppPermissions.Usage.EXTERNAL_FILES_ACCESS,
+                            Runnable {
                                 // Get the file
                                 val file = File(Environment.getExternalStorageDirectory(), s[1])
 
@@ -397,10 +397,10 @@ object OrgFormatter {
                                         currentActivity.showSnackbar(R.string.external_file_no_app_found)
                                     }
                                 } else {
-                                    currentActivity.showSnackbar(String.format(context.getString(R.string.external_file_not_found), file.absolutePath))
+                                    currentActivity.showSnackbar(context.getString(R.string.external_file_not_found, file.absolutePath))
                                 }
                             }
-                        }
+                        );
                     }
                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,6 +238,7 @@
     <string name="permissions_rationale_for_local_repo">Syncing with a local directory requires storage permission</string>
     <string name="permissions_rationale_for_book_export">Exporting notebook requires storage permission</string>
     <string name="permissions_rationale_for_sync_start">Syncing with local repositories requires storage permission</string>
+    <string name="permissions_rationale_for_external_files_access">Accessing external files requires storage permission</string>
 
     <string name="cycle_visibility">Fold/Unfold All</string>
     <string name="running_database_update">Upgrading database…</string>
@@ -533,5 +534,8 @@
     <string name="always_show_set">Always show set</string>
     <string name="show_selected">Show selected</string>
     <string name="hide_all">Hide all</string>
+
+    <string name="external_file_no_app_found">No application found to open this file format</string>
+    <string name="external_file_not_found">File %1$s does not exist</string>
 
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <root-path name="sdcard" path="/sdcard/" />
+    <external-path name="external-files" path="."/>
 </paths>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <root-path name="sdcard" path="/sdcard/" />
+</paths>


### PR DESCRIPTION
Hello,

This is an attempt at implementing file links within orgzly (linked to #360).
Fow now, it will only work with the `file:path` link form, but tuning the regex might enable other forms.

This MR uses the file provider of Android, which should apparently be the way to go since Android 7.0. It tries to find the file links in the content, creates a `content://` link for a file in the internal storage (Right now the base path is /sdcard) and finally tries to open the file with an `ACTION_VIEW` intent.

This seems to be working quite fine, as I tested it and was able to open png, jpg and pdf files (on the Pixel 2 XL emulator with Android 8.1).

Things that won't be working as of now:
- If you have a space in the path to your file, the regex matcher will stop at it, preventing you to get the full path

This is my first time working with kotlin, so there might be mistakes.

Also thanks to @nevenz for this great app and to @halvorlu for his MR #342, that I followed and it helped me in trying to implement this.
