### PR TITLE
Fix broken UI actions after setting change

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/CommonActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/CommonActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
 import android.preference.PreferenceManager
 import android.support.annotation.StringRes
 import android.support.design.widget.Snackbar
@@ -213,10 +214,8 @@ abstract class CommonActivity : AppCompatActivity() {
         if (restartActivity) {
             Loaders.destroyAll(supportLoaderManager)
 
-            recreate()
-            // Handler().post(this@CommonActivity::recreate)
+            Handler().post(this@CommonActivity::recreate)
             restartActivity = false
-
         }
     }
 


### PR DESCRIPTION
Hello,

This MR should fix #348.
The behavior before this MR when changing a setting and going back to notebook list was: onResume, onResumeFragments, onPause, onResume, onResumeFragments and onPause, thus blocking the UI by removing actions from the `LocalBroadcastManager` with the last onPause.
This MR changes the behavior of CommonActivity, so the call stack becomes: onResume, onResumeFragments, onPause, onResume and onResumeFragments, leaving all the actions available to the `LocalBroadcastManager`.