### PR TITLE
Add support for opening org-protocol://org-id-goto links

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/OrgProtocolTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/OrgProtocolTest.java
@@ -1,0 +1,128 @@
+package com.orgzly.android.espresso;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.rule.ActivityTestRule;
+import android.view.View;
+
+import com.orgzly.R;
+import com.orgzly.android.AppIntent;
+import com.orgzly.android.NotePosition;
+import com.orgzly.android.OrgzlyTest;
+import com.orgzly.android.ui.MainActivity;
+import com.orgzly.android.ui.ShareActivity;
+
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.orgzly.android.espresso.EspressoUtils.onSnackbar;
+import static com.orgzly.android.espresso.EspressoUtils.toLandscape;
+import static com.orgzly.android.espresso.EspressoUtils.toPortrait;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+@SuppressWarnings("unchecked")
+public class OrgProtocolTest extends OrgzlyTest {
+    @Rule
+    public ActivityTestRule activityRule = new ActivityTestRule<>(MainActivity.class, true, false);
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        shelfTestUtils.setupBook("book-a",
+                "* Note [b-1]\n" +
+                        ":PROPERTIES:\n" +
+                        ":CUSTOM_ID: DIFFERENT case CUSTOM id\n" +
+                        ":END:\n" +
+
+                        "* Note [b-2]\n" +
+                        ":PROPERTIES:\n" +
+                        ":END:\n" +
+
+                        "* Note [b-3]\n" +
+                        ":PROPERTIES:\n" +
+                        ":CUSTOM_ID: Link to note in a different book\n" +
+                        ":END:\n" +
+                        ""
+        );
+        shelfTestUtils.setupBook("book-b",
+                "* Note [b-4]\n" +
+                        ":PROPERTIES:\n" +
+                        ":ID: BDCE923B-C3CD-41ED-B58E-8BDF8BABA54F\n" +
+                        ":END:\n" +
+
+                        ""
+        );
+
+    }
+    private void startActivityWithIntent(String action, Uri uri) {
+        Intent intent = new Intent();
+
+        if (action != null) {
+            intent.setAction(action);
+        }
+        intent.setData(uri);
+
+        activityRule.launchActivity(intent);
+    }
+
+    @Test
+    public void testOrgProtocolOpensNote() {
+        Uri uri = Uri.parse("org-protocol://org-id-goto?id=BDCE923B-C3CD-41ED-B58E-8BDF8BABA54F");
+        startActivityWithIntent(Intent.ACTION_VIEW,  uri);
+        toPortrait(activityRule);
+
+
+        ViewInteraction textView = onView(
+                allOf(withId(R.id.fragment_note_location),
+                        isDisplayed()));
+        textView.check(matches(withText("book-b")));
+
+        ViewInteraction editText = onView(
+                allOf(withId(R.id.fragment_note_title),
+                        isDisplayed()));
+        editText.check(matches(withText("Note [b-4]")));
+    }
+
+    @Test
+    public void testOrgProtocolBadLink1() {
+        Uri uri = Uri.parse("org-protocol://org-id-goto://BDCE923B-C3CD-41ED-B58E-8BDF8BABA54F");
+        startActivityWithIntent(Intent.ACTION_VIEW,  uri);
+        toPortrait(activityRule);
+
+        ViewInteraction textView = onView(
+                allOf(withId(R.id.snackbar_text),
+                        isDisplayed()));
+
+        textView.check(matches(withText("Note with “ID” property set to “org-protocol://org-id-goto://BDCE923B-C3CD-41ED-B58E-8BDF8BABA54F” not found")));
+
+    }
+    @Test
+    public void testOrgProtocolBadLink2() {
+        Uri uri = Uri.parse("org-protocol://some-other-protocol?x=1&y=2");
+        startActivityWithIntent(Intent.ACTION_VIEW,  uri);
+        toPortrait(activityRule);
+
+        ViewInteraction textView = onView(
+                allOf(withId(R.id.snackbar_text),
+                        isDisplayed()));
+
+        textView.check(matches(withText("Note with “url” property set to “org-protocol://some-other-protocol?x=1&y=2” not found")));
+
+    }
+
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,12 @@
             android:windowSoftInputMode="stateAlwaysHidden">
 
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="org-protocol" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>

--- a/app/src/main/java/com/orgzly/android/ActionService.kt
+++ b/app/src/main/java/com/orgzly/android/ActionService.kt
@@ -130,6 +130,7 @@ class ActionService : JobIntentService() {
             enqueueWork(context, intent)
         }
 
+        @JvmStatic
         fun enqueueWork(context: Context, intent: Intent) {
             JobIntentService.enqueueWork(
                     context,

--- a/app/src/main/java/com/orgzly/android/AppIntent.java
+++ b/app/src/main/java/com/orgzly/android/AppIntent.java
@@ -26,8 +26,8 @@ public class AppIntent {
     public static final String ACTION_CLEAR_DATABASE = "com.orgzly.intent.action.CLEAR_DATABASE";
 
     public static final String ACTION_OPEN_NOTE = "com.orgzly.intent.action.OPEN_NOTE";
-    public static final String ACTION_OPEN_QUERIES = "com.orgzly.intent.action.OPEN_QUERY";
-    public static final String ACTION_OPEN_QUERY = "com.orgzly.intent.action.OPEN_QUERIES";
+    public static final String ACTION_OPEN_QUERIES = "com.orgzly.intent.action.OPEN_QUERIES";
+    public static final String ACTION_OPEN_QUERY = "com.orgzly.intent.action.OPEN_QUERY";
     public static final String ACTION_OPEN_BOOKS = "com.orgzly.intent.action.OPEN_BOOKS";
     public static final String ACTION_OPEN_BOOK = "com.orgzly.intent.action.OPEN_BOOK";
     public static final String ACTION_OPEN_SETTINGS = "com.orgzly.intent.action.OPEN_SETTINGS";

--- a/app/src/main/java/com/orgzly/android/ui/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/MainActivity.java
@@ -134,10 +134,6 @@ public class MainActivity extends CommonActivity
             Notifications.createNewNoteNotification(this);
         }
 
-        Intent intent = getIntent();
-        if (intent.getAction().equalsIgnoreCase("android.intent.action.VIEW")) {
-            handleOrgProtocol(intent);
-        }
     }
 
     private void handleOrgProtocol(Intent intent) {
@@ -159,7 +155,6 @@ public class MainActivity extends CommonActivity
         } else {
             String msg = getString(R.string.no_such_link_target, "url", data.toString());
             showSnackbar(msg);
-
         }
     }
 
@@ -186,6 +181,11 @@ public class MainActivity extends CommonActivity
                 }
             } else if (queryString != null) {
                 DisplayManager.displayQuery(getSupportFragmentManager(), queryString);
+            }
+
+            Intent intent = getIntent();
+            if (intent.getAction().equalsIgnoreCase("android.intent.action.VIEW")) {
+                handleOrgProtocol(intent);
             }
         }
     }


### PR DESCRIPTION
I'm finding Orgzly really useful!  One feature I wanted was to be able to open notes from external links.  It's possible to do this in Emacs using `org-protocol` - https://orgmode.org/worg/org-contrib/org-protocol.html - and I've set up a handler on my PC to use `org-id-goto` so I can generate links into my Org files from a web page. 

(This is useful in conjunction with some other tools that can generate web pages summarizing Org files, for instance to help with GTD reviews.)

The attached patch allows the same links to work in Orgzly, so I can click through from a web page on my phone into the relevant note.

I appreciate it's a bit customized!  Both the `org-protocol` standard, and the `org-id-goto` functions are part of org, but `org-protocol://org-id-goto` is specific to my setup.  Is there anything else people might want to use these links for, or a more generic way of doing something like this?