### PR TITLE
Allow Android M Direct Share to individual Orgzly books

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,10 @@
                 <action android:name="com.google.android.gm.action.AUTO_SEND"/>
                 <data android:mimeType="text/plain"/>
             </intent-filter>
+
+            <meta-data
+                android:name="android.service.chooser.chooser_target_service"
+                android:value=".android.ChooserShareTargetService" />
         </activity>
 
         <activity
@@ -136,6 +140,15 @@
         <service
             android:name=".android.ActionService"
             android:permission="android.permission.BIND_JOB_SERVICE"/>
+
+        <service
+            android:name=".android.ChooserShareTargetService"
+            android:label="@string/share_target_service"
+            android:permission="android.permission.BIND_CHOOSER_TARGET_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.chooser.ChooserTargetService" />
+            </intent-filter>
+        </service>
 
         <!-- Not exported (not made available to other applications). -->
         <provider

--- a/app/src/main/java/com/orgzly/android/Book.java
+++ b/app/src/main/java/com/orgzly/android/Book.java
@@ -56,6 +56,7 @@ public class Book {
         this.preface = preface;
         this.modificationTime = modificationTime;
         this.isDummy = isDummy;
+        orgFileSettings = OrgFileSettings.fromPreface(preface);
     }
 
     public void setId(long id) {
@@ -72,6 +73,7 @@ public class Book {
 
     public void setPreface(String preface) {
         this.preface = preface;
+        orgFileSettings = OrgFileSettings.fromPreface(preface);
     }
 
     public String getName() {

--- a/app/src/main/java/com/orgzly/android/ChooserShareTargetService.kt
+++ b/app/src/main/java/com/orgzly/android/ChooserShareTargetService.kt
@@ -12,6 +12,9 @@ import kotlinx.android.synthetic.main.activity_bookchooser.view.*
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import com.orgzly.R
+import com.orgzly.android.query.Condition
+import com.orgzly.android.query.Query
+import com.orgzly.android.query.user.DottedQueryBuilder
 
 private const val DIRECT_SHARE = "ORGZLY_DIRECT_SHARE";
 
@@ -29,7 +32,8 @@ class ChooserShareTargetService : ChooserTargetService() {
                 continue;
             val bundle : Bundle = Bundle();
             val score : Float = 1.0F; // Can we guess a score based on recent use or content?
-            bundle.putString(AppIntent.EXTRA_FILTER, "b.\"" + book.name + "\"");
+            val query = DottedQueryBuilder().build(Query(Condition.InBook(book.name)));
+            bundle.putString(AppIntent.EXTRA_FILTER, query)
             targets.add(ChooserTarget(book.name, icon, score, componentName, bundle ));
         }
         return targets;

--- a/app/src/main/java/com/orgzly/android/ChooserShareTargetService.kt
+++ b/app/src/main/java/com/orgzly/android/ChooserShareTargetService.kt
@@ -13,6 +13,7 @@ import android.graphics.BitmapFactory
 import android.os.Bundle
 import com.orgzly.R
 
+private const val DIRECT_SHARE = "ORGZLY_DIRECT_SHARE";
 
 @RequiresApi(Build.VERSION_CODES.M)
 class ChooserShareTargetService : ChooserTargetService() {
@@ -23,6 +24,9 @@ class ChooserShareTargetService : ChooserTargetService() {
 
         val icon = Icon.createWithResource(this, R.drawable.ic_logo_for_widget);
         for (book in shelf.books) {
+            val direct = book.orgFileSettings.getLastKeywordValue(DIRECT_SHARE);
+            if (direct.isNullOrBlank())
+                continue;
             val bundle : Bundle = Bundle();
             val score : Float = 1.0F; // Can we guess a score based on recent use or content?
             bundle.putString(AppIntent.EXTRA_FILTER, "b.\"" + book.name + "\"");

--- a/app/src/main/java/com/orgzly/android/ChooserShareTargetService.kt
+++ b/app/src/main/java/com/orgzly/android/ChooserShareTargetService.kt
@@ -1,0 +1,34 @@
+package com.orgzly.android
+
+import android.app.PendingIntent
+import android.content.ComponentName
+import android.content.IntentFilter
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.chooser.ChooserTarget
+import android.service.chooser.ChooserTargetService
+import android.support.annotation.RequiresApi
+import kotlinx.android.synthetic.main.activity_bookchooser.view.*
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import com.orgzly.R
+
+
+@RequiresApi(Build.VERSION_CODES.M)
+class ChooserShareTargetService : ChooserTargetService() {
+    private val shelf = Shelf(this)
+
+    override fun onGetChooserTargets(componentName: ComponentName?, intentFilter: IntentFilter?): MutableList<ChooserTarget> {
+        val targets = arrayListOf<ChooserTarget>();
+
+        val icon = Icon.createWithResource(this, R.drawable.ic_logo_for_widget);
+        for (book in shelf.books) {
+            val bundle : Bundle = Bundle();
+            val score : Float = 1.0F; // Can we guess a score based on recent use or content?
+            bundle.putString(AppIntent.EXTRA_FILTER, "b.\"" + book.name + "\"");
+            targets.add(ChooserTarget(book.name, icon, score, componentName, bundle ));
+        }
+        return targets;
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -536,5 +536,6 @@
     <string name="hide_all">Hide all</string>
 
     <string name="external_file_no_app_found">No application found to open this file</string>
+    <string name="share_target_service">Share to Orgzly book</string>
 
 </resources>


### PR DESCRIPTION
Do we want to allow sharing directly to individual notebooks from Android M, using the "direct share" feature?

Perhaps we also need a way to let the user control which books should be share targets?