### PR TITLE
Basic org-capture implementation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,8 +105,8 @@
         </activity>
 
         <activity
-            android:name="com.orgzly.android.ui.CaptureChooserActivity"
-            android:label="@string/capture_shortcut_label"
+            android:name="com.orgzly.android.ui.TemplateChooserActivity"
+            android:label="@string/new_note_shortcut_label"
             android:icon="@mipmap/cic_shortcut_new_note">
 
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,6 +105,17 @@
         </activity>
 
         <activity
+            android:name="com.orgzly.android.ui.CaptureChooserActivity"
+            android:label="@string/capture_shortcut_label"
+            android:icon="@mipmap/cic_shortcut_new_note">
+
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name="com.dropbox.core.android.AuthActivity"
             android:configChanges="orientation|keyboard"
             android:launchMode="singleTask">

--- a/app/src/main/java/com/orgzly/android/di/module/AndroidModule.kt
+++ b/app/src/main/java/com/orgzly/android/di/module/AndroidModule.kt
@@ -6,7 +6,7 @@ import com.orgzly.android.usecase.UseCaseService
 import com.orgzly.android.reminders.ReminderService
 import com.orgzly.android.sync.SyncService
 import com.orgzly.android.ui.BookChooserActivity
-import com.orgzly.android.ui.CaptureChooserActivity
+import com.orgzly.android.ui.TemplateChooserActivity
 import com.orgzly.android.ui.books.BooksFragment
 import com.orgzly.android.ui.notes.book.BookPrefaceFragment
 import com.orgzly.android.ui.savedsearch.SavedSearchFragment
@@ -86,7 +86,7 @@ internal abstract class AndroidModule {
     internal abstract fun contributeBookChooserActivity(): BookChooserActivity
 
     @ContributesAndroidInjector
-    internal abstract fun contributeCaptureChooserActivity(): CaptureChooserActivity
+    internal abstract fun contributeTemplateChooserActivity(): TemplateChooserActivity
 
     @ContributesAndroidInjector
     internal abstract fun contributeListWidgetSelectionActivity(): ListWidgetSelectionActivity

--- a/app/src/main/java/com/orgzly/android/di/module/AndroidModule.kt
+++ b/app/src/main/java/com/orgzly/android/di/module/AndroidModule.kt
@@ -6,6 +6,7 @@ import com.orgzly.android.usecase.UseCaseService
 import com.orgzly.android.reminders.ReminderService
 import com.orgzly.android.sync.SyncService
 import com.orgzly.android.ui.BookChooserActivity
+import com.orgzly.android.ui.CaptureChooserActivity
 import com.orgzly.android.ui.books.BooksFragment
 import com.orgzly.android.ui.notes.book.BookPrefaceFragment
 import com.orgzly.android.ui.savedsearch.SavedSearchFragment
@@ -83,6 +84,9 @@ internal abstract class AndroidModule {
 
     @ContributesAndroidInjector
     internal abstract fun contributeBookChooserActivity(): BookChooserActivity
+
+    @ContributesAndroidInjector
+    internal abstract fun contributeCaptureChooserActivity(): CaptureChooserActivity
 
     @ContributesAndroidInjector
     internal abstract fun contributeListWidgetSelectionActivity(): ListWidgetSelectionActivity

--- a/app/src/main/java/com/orgzly/android/ui/BookChooserActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/BookChooserActivity.java
@@ -27,7 +27,7 @@ public class BookChooserActivity extends CommonActivity
 
     public static final String TAG = BookChooserActivity.class.getName();
 
-    private String action;
+    protected String action;
 
     @Inject
     DataRepository dataRepository;

--- a/app/src/main/java/com/orgzly/android/ui/CaptureChooserActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/CaptureChooserActivity.java
@@ -1,0 +1,55 @@
+package com.orgzly.android.ui;
+
+import android.content.Intent;
+import android.widget.Toast;
+
+import androidx.core.content.pm.ShortcutInfoCompat;
+import androidx.core.content.pm.ShortcutManagerCompat;
+import androidx.core.graphics.drawable.IconCompat;
+
+import com.orgzly.R;
+import com.orgzly.android.BookUtils;
+import com.orgzly.android.db.entity.Book;
+import com.orgzly.android.ui.share.ShareActivity;
+
+public class CaptureChooserActivity extends BookChooserActivity {
+    @Override
+    public void onBookClicked(long bookId) {
+        if (action == null) {
+            return;
+        }
+        if (!action.equals(Intent.ACTION_CREATE_SHORTCUT)) {
+            return;
+        }
+            Book book = dataRepository.getBook(bookId);
+
+            if (book == null) {
+                Toast.makeText(this, R.string.book_does_not_exist_anymore, Toast.LENGTH_SHORT).show();
+                setResult(RESULT_CANCELED);
+                finish();
+                return;
+            }
+
+            String id = "capture-" + bookId;
+            String name = book.getName();
+            String title = BookUtils.getFragmentTitleForBook(book);
+            Intent launchIntent = ShareActivity.createNewNoteInNotebookIntent(this, bookId);
+            IconCompat icon = createIcon();
+
+            ShortcutInfoCompat shortcut =
+                    new ShortcutInfoCompat.Builder(this, id)
+                            .setShortLabel(name)
+                            .setLongLabel(title)
+                            .setIcon(icon)
+                            .setIntent(launchIntent)
+                            .build();
+
+            setResult(RESULT_OK, ShortcutManagerCompat.createShortcutResultIntent(this, shortcut));
+
+            finish();
+    }
+
+    private IconCompat createIcon() {
+        return IconCompat.createWithResource(this, R.mipmap.cic_shortcut_new_note);
+    }
+}

--- a/app/src/main/java/com/orgzly/android/ui/TemplateChooserActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/TemplateChooserActivity.java
@@ -12,7 +12,7 @@ import com.orgzly.android.BookUtils;
 import com.orgzly.android.db.entity.Book;
 import com.orgzly.android.ui.share.ShareActivity;
 
-public class CaptureChooserActivity extends BookChooserActivity {
+public class TemplateChooserActivity extends BookChooserActivity {
     @Override
     public void onBookClicked(long bookId) {
         if (action == null) {
@@ -30,7 +30,7 @@ public class CaptureChooserActivity extends BookChooserActivity {
                 return;
             }
 
-            String id = "capture-" + bookId;
+            String id = "template-" + bookId;
             String name = book.getName();
             String title = BookUtils.getFragmentTitleForBook(book);
             Intent launchIntent = ShareActivity.createNewNoteInNotebookIntent(this, bookId);

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -149,6 +149,10 @@ public class ShareActivity extends CommonActivity
                     }
                 }
 
+                if (intent.hasExtra(AppIntent.EXTRA_BOOK_ID)) {
+                    data.bookId = intent.getLongExtra(AppIntent.EXTRA_BOOK_ID, 0L);
+                }
+
             } else {
                 mError = getString(R.string.share_type_not_supported, type);
             }
@@ -219,10 +223,7 @@ public class ShareActivity extends CommonActivity
     }
 
     public static PendingIntent createNewNoteIntent(Context context, SavedSearch savedSearch) {
-        Intent resultIntent = new Intent(context, ShareActivity.class);
-        resultIntent.setAction(Intent.ACTION_SEND);
-        resultIntent.setType("text/plain");
-        resultIntent.putExtra(Intent.EXTRA_TEXT, "");
+        Intent resultIntent = createNewNoteInNotebookIntent(context, null);
 
         if (savedSearch != null && savedSearch.getQuery() != null) {
             resultIntent.putExtra(AppIntent.EXTRA_QUERY_STRING, savedSearch.getQuery());
@@ -240,6 +241,20 @@ public class ShareActivity extends CommonActivity
 
 //        return PendingIntent.getActivity(context, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         return stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+    /**
+     * @param bookId null means default
+     */
+    public static Intent createNewNoteInNotebookIntent(Context context, Long bookId) {
+           Intent intent = new Intent(context, ShareActivity.class);
+           intent.setAction(Intent.ACTION_SEND);
+           intent.setType("text/plain");
+           intent.putExtra(Intent.EXTRA_TEXT, "");
+           if (bookId != null) {
+               intent.putExtra(AppIntent.EXTRA_BOOK_ID, bookId);
+           }
+           return intent;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,6 +231,7 @@
     <string name="no_filters">You have no saved searches</string>
 
     <string name="book_shortcut_label">Orgzly notebook</string>
+    <string name="capture_shortcut_label">Orgzly capture</string>
     <string name="pick_a_notebook">Pick a notebook</string>
 
     <string name="down">Down</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,7 +231,7 @@
     <string name="no_filters">You have no saved searches</string>
 
     <string name="book_shortcut_label">Orgzly notebook</string>
-    <string name="capture_shortcut_label">Orgzly capture</string>
+    <string name="new_note_shortcut_label">New note</string>
     <string name="pick_a_notebook">Pick a notebook</string>
 
     <string name="down">Down</string>


### PR DESCRIPTION
Related issue: https://github.com/orgzly/orgzly-android/issues/80 

This is a very minimalistic implementation, basically, just a shorthand to creating a note in a specific notebook. But it'd be a necessary step towards implementing proper capture anyway, so I think it makes sense to do it now considering that actually supporting templates would be a bit more complicated.

In my vision, in future when we do support templates, you'd just have a UI prompting you for notebook and also asking you to choose from one of the predefined capture templates. Then the template is passed to the share intent and handled by the fragment that creates notes (e.g. filling up default todo state/tags/etc). If you don't recieve a template in the intent, you just create a note in the target notebook. So the behaviour would be backwards compatible.

There is a fair bit of copy-pasting in `CaptureChooserActivity.onBookClicked` from `BookChooserActivity.onBookClicked`.. but not too much. Let me know if you think it should be generified.

Let me know if there is anything you think needs improvement here. If this all reasonable, I'll implement some tests too, just want to make sure this approach looks fine to you.