### PR TITLE
add option to remove common indent from note body

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/SettingsChangeTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/SettingsChangeTest.java
@@ -12,10 +12,13 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.orgzly.android.espresso.EspressoUtils.clickSetting;
 import static com.orgzly.android.espresso.EspressoUtils.onActionItemClick;
@@ -45,7 +48,9 @@ public class SettingsChangeTest extends OrgzlyTest {
                 "SCHEDULED: <2018-01-01>\n" +
                 "Content for [a-1]\n" +
                 "* Note [a-2]\n" +
-                "SCHEDULED: <2014-01-01>\n"
+                "SCHEDULED: <2014-01-01>\n" +
+                "* Indented content\n" +
+                "    indented note content"
         );
 
         activityRule.launchActivity(null);
@@ -99,6 +104,32 @@ public class SettingsChangeTest extends OrgzlyTest {
         pressBack();
 
         onNoteInBook(1, R.id.item_head_content).check(matches(not(isDisplayed())));
+    }
+
+    @Test
+    public void testRemoveIndent() {
+        onBook(0).perform(click());
+        onNoteInBook(3, R.id.item_head_content)
+                .check(matches(withText("indented note content")));
+        onNoteInBook(3).perform(longClick());
+        onView(withId(R.id.body_view)).check(matches(withText("indented note content")));
+        onView(withId(R.id.body_edit)).check(matches(withText("    indented note content")));
+        pressBack();
+        pressBack();
+
+        // Disable remove indent setting
+        onActionItemClick(R.id.activity_action_settings, R.string.settings);
+        clickSetting("prefs_screen_look_and_feel", R.string.look_and_feel);
+        clickSetting("pref_key_remove_indent_from_body", R.string.remove_indent_from_body);
+        pressBack();
+        pressBack();
+
+        onBook(0).perform(click());
+        onNoteInBook(3, R.id.item_head_content)
+                .check(matches(withText("    indented note content")));
+        onNoteInBook(3).perform(longClick());
+        onView(withId(R.id.body_view)).check(matches(withText("    indented note content")));
+        onView(withId(R.id.body_edit)).check(matches(withText("    indented note content")));
     }
 
     private void setDefaultPriority(String priority) {

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -153,6 +153,17 @@ public class AppPreferences {
                 context.getResources().getBoolean(R.bool.pref_default_is_font_monospaced));
     }
 
+    public static boolean removeIndentFromBody(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_remove_indent_from_body),
+                context.getResources().getBoolean(R.bool.pref_default_remove_indent_from_body));
+    }
+
+    public static void removeIndentFromBody(Context context, boolean value) {
+        String key = context.getResources().getString(R.string.pref_key_remove_indent_from_body);
+        getDefaultSharedPreferences(context).edit().putBoolean(key, value).apply();
+    }
+
     public static boolean styleText(Context context) {
         return getDefaultSharedPreferences(context).getBoolean(
                 context.getResources().getString(R.string.pref_key_style_text),

--- a/app/src/main/java/com/orgzly/android/ui/util/ViewUtils.java
+++ b/app/src/main/java/com/orgzly/android/ui/util/ViewUtils.java
@@ -41,4 +41,28 @@ public class ViewUtils {
 
         return result;
     }
+
+    public static String removeIndent(CharSequence text) {
+        int indentCount = Integer.MAX_VALUE;
+        String[] lines = text.toString().split("\n");
+        for (String line: lines) {
+            int indentCountCurrentLine = 0;
+            for (int i = 0; i < line.length(); i++) {
+                if (line.charAt(i) == ' ') {
+                    indentCountCurrentLine++;
+                } else {
+                    break;
+                }
+            }
+
+            indentCount = Math.min(indentCount, indentCountCurrentLine);
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        for (String line: lines) {
+            stringBuilder.append(line.substring(indentCount));
+        }
+
+        return stringBuilder.toString();
+    }
 }

--- a/app/src/main/java/com/orgzly/android/ui/views/TextViewWithMarkup.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/TextViewWithMarkup.kt
@@ -8,7 +8,9 @@ import android.util.AttributeSet
 import android.util.Log
 import android.widget.TextView
 import com.orgzly.BuildConfig
+import com.orgzly.android.prefs.AppPreferences
 import com.orgzly.android.ui.main.MainActivity
+import com.orgzly.android.ui.util.ViewUtils
 import com.orgzly.android.ui.views.style.CheckboxSpan
 import com.orgzly.android.ui.views.style.DrawerEndSpan
 import com.orgzly.android.ui.views.style.DrawerSpan
@@ -32,7 +34,10 @@ class TextViewWithMarkup : TextViewFixed {
     fun setRawText(text: CharSequence) {
         rawText = text
 
-        setText(OrgFormatter.parse(text, context), BufferType.SPANNABLE)
+        val formattedText = OrgFormatter.parse(text, context)
+        val textToDisplay = if (AppPreferences.removeIndentFromBody(context))
+            ViewUtils.removeIndent(formattedText) else formattedText
+        setText(textToDisplay, BufferType.SPANNABLE)
     }
 
     fun getRawText() : CharSequence? {

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -63,6 +63,9 @@
     <string name="pref_key_is_font_monospaced" translatable="false">pref_key_is_font_monospaced</string>
     <bool name="pref_default_is_font_monospaced" translatable="false">false</bool>
 
+    <string name="pref_key_remove_indent_from_body" translatable="false">pref_key_remove_indent_from_body</string>
+    <bool name="pref_default_remove_indent_from_body" translatable="false">true</bool>
+
     <string name="pref_key_style_text" translatable="false">pref_key_style_text</string>
     <bool name="pref_default_style_text" translatable="false">true</bool>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,6 +305,7 @@
     <string name="color_scheme">Color scheme</string>
     <string name="monospaced_font">Monospaced font</string>
     <string name="monospaced_font_summary">Use monospaced font for note\'s content and notebook\'s preface</string>
+    <string name="remove_indent_from_body">Remove indentation from body of items</string>
     <string name="reversed_note_click_action">Swap note click and long-click actions</string>
     <string name="reversed_note_click_action_summary">Click to select note, long-click to open</string>
     <string name="look_and_feel">Look &amp; Feel</string>

--- a/app/src/main/res/xml/prefs_screen_look_and_feel.xml
+++ b/app/src/main/res/xml/prefs_screen_look_and_feel.xml
@@ -31,6 +31,11 @@
         android:defaultValue="@bool/pref_default_is_font_monospaced"/>
 
     <SwitchPreference
+        android:key="@string/pref_key_remove_indent_from_body"
+        android:title="@string/remove_indent_from_body"
+        android:defaultValue="@bool/pref_default_remove_indent_from_body"/>
+
+    <SwitchPreference
         android:key="@string/pref_key_style_text"
         android:title="@string/style_text_title"
         android:summary="@string/style_text_summary"


### PR DESCRIPTION
For example:
```
* foo
** bar
   example content
     deeper indent
```
will display
```
example content
  deeper indent
```
instead of
```
   example content
     deeper indent
```
as text of a note.

This does not apply to the EditText, because it might confuse the user when
typing spaces at the beginning of a line, as they wouldn't show up if they are
part of a common indent.

The reasoning behind this feature is, that indents in Emacs Org-Mode are by
default as deep as needed to match the text of the innermost subheading 
that contains the body to be indented.