### PR TITLE
Enable orgzly to receive shared image

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,11 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:dist="http://schemas.android.com/apk/distribution"
     package="com.orgzly"
     android:installLocation="auto">
+
+    <dist:module dist:instant="true" />
 
     <!-- Initially added for Dropbox sync. -->
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -45,6 +48,11 @@
                 <action android:name="com.google.android.gm.action.AUTO_SEND"/>
                 <data android:mimeType="text/plain"/>
             </intent-filter>
+	    <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+		<category android:name="android.intent.category.DEFAULT" />
+		<data android:mimeType="image/*" />
+	    </intent-filter>
 
             <meta-data
                 android:name="android.service.chooser.chooser_target_service"

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -245,7 +245,7 @@ public class ShareActivity extends CommonActivity
         // Adds the Intent that starts the Activity to the top of the stack
         stackBuilder.addNextIntent(resultIntent);
 
-//        return PendingIntent.getActivity(context, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        // return PendingIntent.getActivity(context, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         return stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -330,7 +330,10 @@ public class ShareActivity extends CommonActivity
 	    int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
 	    cursor.moveToFirst();
 	    return cursor.getString(column_index);
-	} finally {
+	} catch (Exception e) {
+            e.printStackTrace();
+            return "Failed reading the content of " + contentUri.toString() + ": " + e.toString();
+        } finally {
 	    if (cursor != null) {
 		cursor.close();
 	    }


### PR DESCRIPTION
Thanks for this app and for making it open source. I love orgzly. To quickly annotate/schedule photos or screenshots I needed orgzly to allow me to share image files with it. So I added the code for this functionality. 
I built and tested it with success on my device. 

Thanks again.

P.S.: Line 6, 10 and 11 in AndroidManifest.xml are not needed leftovers inserted while getting the app to run on my device beside the 'real' orgzly app. Sorry for leaving them in the commit. They can be removed. Let me now if I shall add a new commit to remove them. I ended up using applicationIdSuffix ".debug" inside the debug buildType in the build.gradle file instead.