### PR TITLE
Add preference to set default reminder time

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -311,6 +311,17 @@ public class AppPreferences {
                 context.getResources().getString(R.string.pref_default_snooze_type));
     }
 
+    public static int reminderDailyTime(Context context) {
+        String key = context.getResources().getString(R.string.pref_key_daily_reminder_time);
+        return getStateSharedPreferences(context).getInt(key,
+                context.getResources().getInteger(R.integer.pref_default_daily_reminder_time));
+    }
+
+    public static void reminderDailyTime(Context context, int value) {
+        String key = context.getResources().getString(R.string.pref_key_daily_reminder_time);
+        getStateSharedPreferences(context).edit().putInt(key, value).apply();
+    }
+
     public static boolean showSyncNotifications(Context context) {
         return getDefaultSharedPreferences(context).getBoolean(
                 context.getResources().getString(R.string.pref_key_show_sync_notifications),

--- a/app/src/main/java/com/orgzly/android/prefs/TimePreference.kt
+++ b/app/src/main/java/com/orgzly/android/prefs/TimePreference.kt
@@ -1,0 +1,49 @@
+package com.orgzly.android.prefs
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.text.format.DateFormat
+import android.util.AttributeSet
+
+import androidx.preference.DialogPreference
+import com.orgzly.R
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+
+class TimePreference : DialogPreference {
+
+    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
+        dialogLayoutResource = R.layout.pref_dialog_time
+    }
+
+    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+        dialogLayoutResource = R.layout.pref_dialog_time
+    }
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+        dialogLayoutResource = R.layout.pref_dialog_time
+    }
+
+    override fun onGetDefaultValue(a: TypedArray, index: Int): Any? {
+        return a.getString(index)
+    }
+
+    override fun getSummary(): CharSequence {
+        val timeFormat = DateFormat.getTimeFormat(context)
+
+        val time = DateTime.now(DateTimeZone.forTimeZone(timeFormat.timeZone))
+                .withTimeAtStartOfDay()
+                .plusMinutes(getTime())
+                .toDate()
+
+        return timeFormat.format(time)
+    }
+
+    fun getTime(): Int {
+        return AppPreferences.reminderDailyTime(context)
+    }
+
+    fun setTime(time: Int) {
+        AppPreferences.reminderDailyTime(context, time)
+    }
+}

--- a/app/src/main/java/com/orgzly/android/reminders/ReminderService.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/ReminderService.kt
@@ -270,7 +270,7 @@ class ReminderService : JobIntentService() {
                     val time = getFirstTime(
                             orgDateTime,
                             interval,
-                            OrgInterval(9, OrgInterval.Unit.HOUR),  // Default time of day
+                            AppPreferences.reminderDailyTime(context),
                             warningPeriod
                     )
 
@@ -381,7 +381,7 @@ class ReminderService : JobIntentService() {
         private fun getFirstTime(
                 orgDateTime: OrgDateTime,
                 interval: Pair<ReadableInstant, ReadableInstant?>,
-                defaultTimeOfDay: OrgInterval,
+                defaultTimeOfDay: Int,
                 warningPeriod: OrgInterval?): DateTime? {
 
             val times = OrgDateTimeUtils.getTimesInInterval(
@@ -392,8 +392,7 @@ class ReminderService : JobIntentService() {
             }
             var time = times[0]
             if (!orgDateTime.hasTime()) {
-                // TODO: Move to preferences
-                time = time.plusHours(9)
+                time = time.plusMinutes(defaultTimeOfDay)
             }
             return time
         }

--- a/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
@@ -140,6 +140,11 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
                         IntegerPreferenceFragment.getInstance(preference),
                         IntegerPreferenceFragment.FRAGMENT_TAG)
 
+            is TimePreference ->
+                displayCustomPreferenceDialogFragment(
+                        TimePreferenceFragment.getInstance(preference),
+                        TimePreferenceFragment.FRAGMENT_TAG)
+
             else -> super.onDisplayPreferenceDialog(preference)
         }
     }
@@ -273,6 +278,13 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             getString(R.string.pref_key_use_reminders_for_event_times) ->
                 AppPreferences.reminderLastRunForEvents(context, 0L)
 
+            getString(R.string.pref_key_daily_reminder_time) -> {
+                AppPreferences.reminderLastRunForScheduled(context, 0L)
+                AppPreferences.reminderLastRunForDeadline(context, 0L)
+                AppPreferences.reminderLastRunForEvents(context, 0L)
+            }
+
+
             // Display images inline enabled - request permission
             getString(R.string.pref_key_images_enabled) -> {
                 if (AppPreferences.imagesEnabled(context)) {
@@ -317,6 +329,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
             preference(R.string.pref_key_snooze_time)?.isEnabled = remindersEnabled
             preference(R.string.pref_key_snooze_type)?.isEnabled = remindersEnabled
+            preference(R.string.pref_key_daily_reminder_time)?.isEnabled = remindersEnabled
         }
     }
 

--- a/app/src/main/res/layout/pref_dialog_time.xml
+++ b/app/src/main/res/layout/pref_dialog_time.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TimePicker
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/time_picker_layout"
+    android:paddingTop="15dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -230,6 +230,10 @@
     <string name="pref_key_reminders_led" translatable="false">pref_key_reminders_led</string>
     <bool name="pref_default_reminders_led" translatable="false">true</bool>
 
+    <string name="pref_key_daily_reminder_time" translatable="false">pref_key_daily_reminder_time</string>
+    <!-- Time in minutes after midnight. 540 minutes == 9 o'clock -->
+    <integer name="pref_default_daily_reminder_time" translatable="false">540</integer>
+
     <!-- Auto-sync -->
 
     <string name="pref_key_auto_sync" translatable="false">pref_key_auto_sync</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -473,6 +473,8 @@
     <string name="pref_title_snooze_time">Snooze time (minutes)</string>
     <string name="pref_title_snooze_type">Snooze type</string>
 
+    <string name="pref_title_daily_reminder_time">Daily reminder time</string>
+
     <string name="primary_storage">Main storage</string>
 
     <string name="book_exported">Notebook exported to %s</string>

--- a/app/src/main/res/xml-v26/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml-v26/prefs_screen_reminders.xml
@@ -49,4 +49,8 @@
         android:entryValues="@array/snooze_type_values"
         android:defaultValue="@string/pref_default_snooze_type"
         app:useSimpleSummaryProvider="true" />
+
+    <com.orgzly.android.prefs.TimePreference
+        android:key="@string/pref_key_daily_reminder_time"
+        android:title="@string/pref_title_daily_reminder_time" />
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml/prefs_screen_reminders.xml
@@ -61,4 +61,8 @@
             android:defaultValue="@string/pref_default_snooze_type"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
+
+    <com.orgzly.android.prefs.TimePreference
+        android:key="@string/pref_key_daily_reminder_time"
+        android:title="@string/pref_title_daily_reminder_time" />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This fixes #651.

The default time for this preference is still 9 o'clock, like it was before. But now a user is able to change this time.