### PR TITLE
encryption of notebooks in sync repos

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,6 +184,9 @@ dependencies {
         // Resolves DuplicatePlatformClasses lint error
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }
+
+    // Encryption
+    implementation "org.bouncycastle:bcpg-jdk15on:1.65"
 }
 
 repositories {

--- a/app/src/main/java/com/orgzly/android/BookName.java
+++ b/app/src/main/java/com/orgzly/android/BookName.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 public class BookName {
     private static final String TAG = BookName.class.getName();
 
-    private static final Pattern PATTERN = Pattern.compile("(.*)\\.(org)(\\.txt)?$");
+    private static final Pattern PATTERN = Pattern.compile("(.*)\\.(org)(\\.txt)?(\\.gpg)?$");
     private static final Pattern SKIP_PATTERN = Pattern.compile("^\\.#.*");
 
     private final String mFileName;

--- a/app/src/main/java/com/orgzly/android/BookName.java
+++ b/app/src/main/java/com/orgzly/android/BookName.java
@@ -20,6 +20,7 @@ public class BookName {
 
     private static final Pattern PATTERN = Pattern.compile("(.*)\\.(org)(\\.txt)?(\\.gpg)?$");
     private static final Pattern SKIP_PATTERN = Pattern.compile("^\\.#.*");
+    private static final Pattern GPG_PATTERN = Pattern.compile("(.*)(\\.gpg)$");
 
     private final String mFileName;
     private final String mName;
@@ -69,6 +70,10 @@ public class BookName {
 
     public static boolean isSupportedFormatFileName(String fileName) {
         return PATTERN.matcher(fileName).matches() && !SKIP_PATTERN.matcher(fileName).matches();
+    }
+
+    public static boolean isEncryptedSupportedFormatFileName(String fileName) {
+        return isSupportedFormatFileName(fileName) && GPG_PATTERN.matcher(fileName).matches();
     }
 
     public static String fileName(String name, BookFormat format) {

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -178,7 +178,6 @@ class DataRepository @Inject constructor(
                         Pair(tmpFileEncrypted, MiscUtils.ensureGpgExtensionFileName(fileName))
                     } else {
                         // remove possible .gpg extension left over from a previous encrypted sync
-                        // ?maybe move this logic to BookView.getFileName()
                         Pair(tmpFile, MiscUtils.ensureNoGpgExtensionFileName(fileName))
                     }
 
@@ -1584,9 +1583,6 @@ class DataRepository @Inject constructor(
         val tmpFileDecrypted = getTempBookFile()
         try {
             /* Download from repo. */
-            // ensure that we don't try to decrypt .org files or interpret .org.gpg as plaintext
-            // problem if both 'nb.org' and 'nb.org.gpg' exist. probably some other mechanism that
-            // runs at a higher level that here should be made aware and responsible of .pgp extensions
             val toRecvFileName = if (repo.isEncryptionEnabled) {
                 MiscUtils.ensureGpgExtensionFileName(fileName)
             } else {

--- a/app/src/main/java/com/orgzly/android/repos/ContentRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/ContentRepo.java
@@ -64,6 +64,12 @@ public class ContentRepo implements SyncRepo {
     }
 
     @Override
+    public boolean isEncryptionEnabled() { return false; }
+
+    @Override
+    public String getEncryptionPassphrase() { return null; }
+
+    @Override
     public List<VersionedRook> getBooks() throws IOException {
         List<VersionedRook> result = new ArrayList<>();
 

--- a/app/src/main/java/com/orgzly/android/repos/DatabaseRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DatabaseRepo.java
@@ -42,6 +42,12 @@ public class DatabaseRepo implements SyncRepo {
     }
 
     @Override
+    public boolean isEncryptionEnabled() { return false; }
+
+    @Override
+    public String getEncryptionPassphrase() { return null; }
+
+    @Override
     public List<VersionedRook> getBooks() {
         return dbRepo.getBooks(repoId, repoUri);
     }

--- a/app/src/main/java/com/orgzly/android/repos/DirectoryRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DirectoryRepo.java
@@ -110,6 +110,12 @@ public class DirectoryRepo implements SyncRepo {
     }
 
     @Override
+    public boolean isEncryptionEnabled() { return false; }
+
+    @Override
+    public String getEncryptionPassphrase() { return null; }
+
+    @Override
     public VersionedRook retrieveBook(String fileName, File destinationFile) throws IOException {
         Uri uri = repoUri.buildUpon().appendPath(fileName).build();
 

--- a/app/src/main/java/com/orgzly/android/repos/DropboxClient.java
+++ b/app/src/main/java/com/orgzly/android/repos/DropboxClient.java
@@ -139,7 +139,7 @@ public class DropboxClient {
         AppPreferences.dropboxToken(mContext, null);
     }
 
-    public List<VersionedRook> getBooks(Uri repoUri) throws IOException {
+    public List<VersionedRook> getBooks(Uri repoUri, boolean encrypted) throws IOException {
         linkedOrThrow();
 
         List<VersionedRook> list = new ArrayList<>();
@@ -163,7 +163,8 @@ public class DropboxClient {
                         if (metadata instanceof FileMetadata) {
                             FileMetadata file = (FileMetadata) metadata;
 
-                            if (BookName.isSupportedFormatFileName(file.getName())) {
+                            if ((!encrypted && BookName.isSupportedFormatFileName(file.getName()))
+                                    || (encrypted && BookName.isEncryptedSupportedFormatFileName(file.getName()))) {
                                 Uri uri = repoUri.buildUpon().appendPath(file.getName()).build();
                                 VersionedRook book = new VersionedRook(
                                         repoId,

--- a/app/src/main/java/com/orgzly/android/repos/DropboxRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DropboxRepo.java
@@ -42,7 +42,7 @@ public class DropboxRepo implements SyncRepo {
 
     @Override
     public List<VersionedRook> getBooks() throws IOException {
-        return client.getBooks(repoUri);
+        return client.getBooks(repoUri, isEncryptionEnabled());
     }
 
     @Override

--- a/app/src/main/java/com/orgzly/android/repos/DropboxRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DropboxRepo.java
@@ -14,10 +14,14 @@ public class DropboxRepo implements SyncRepo {
     public static final String SCHEME = "dropbox";
 
     private final Uri repoUri;
+    private final boolean encryptionEnabled;
+    private final String encryptionPassphrase;
     private final DropboxClient client;
 
     public DropboxRepo(RepoWithProps repoWithProps, Context context) {
         this.repoUri = Uri.parse(repoWithProps.getRepo().getUrl());
+        this.encryptionEnabled = repoWithProps.getProps().containsKey("pgpPassphrase");
+        this.encryptionPassphrase = repoWithProps.getProps().get("pgpPassphrase");
         this.client = new DropboxClient(context, repoWithProps.getRepo().getId());
     }
 
@@ -39,6 +43,16 @@ public class DropboxRepo implements SyncRepo {
     @Override
     public List<VersionedRook> getBooks() throws IOException {
         return client.getBooks(repoUri);
+    }
+
+    @Override
+    public boolean isEncryptionEnabled() {
+        return this.encryptionEnabled;
+    }
+
+    @Override
+    public String getEncryptionPassphrase() {
+        return this.encryptionPassphrase;
     }
 
     @Override

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -298,6 +298,12 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
         return preferences.remoteUri();
     }
 
+    @Override
+    public boolean isEncryptionEnabled() { return false; }
+
+    @Override
+    public String getEncryptionPassphrase() { return null; }
+
     public void delete(Uri deleteUri) throws IOException {
         // FIXME: finish me
         throw new IOException("Don't do that");

--- a/app/src/main/java/com/orgzly/android/repos/MockRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/MockRepo.java
@@ -45,6 +45,12 @@ public class MockRepo implements SyncRepo {
     }
 
     @Override
+    public boolean isEncryptionEnabled() { return false; }
+
+    @Override
+    public String getEncryptionPassphrase() { return null; }
+
+    @Override
     public List<VersionedRook> getBooks() throws IOException {
         SystemClock.sleep(SLEEP_FOR_GET_BOOKS);
         return databaseRepo.getBooks();

--- a/app/src/main/java/com/orgzly/android/repos/SyncRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/SyncRepo.java
@@ -28,6 +28,16 @@ public interface SyncRepo {
     List<VersionedRook> getBooks() throws IOException;
 
     /**
+     * Whether this repo shall be treated as containing encrypted files.
+     */
+    boolean isEncryptionEnabled();
+
+    /**
+     * The PGP passphrase to use for cryptography operations on files in this repo.
+     */
+    String getEncryptionPassphrase();
+
+    /**
      * Download the latest available revision of the book and store its content to {@code File}.
      */
     VersionedRook retrieveBook(String fileName, File destination) throws IOException;

--- a/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
+++ b/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
@@ -125,6 +125,14 @@ class WebdavRepo(
         return uri
     }
 
+    override fun isEncryptionEnabled(): Boolean {
+        return false
+    }
+
+    override fun getEncryptionPassphrase(): String? {
+        return null
+    }
+
     override fun getBooks(): MutableList<VersionedRook> {
         val url = uri.toUrl()
 

--- a/app/src/main/java/com/orgzly/android/ui/repo/dropbox/DropboxRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/dropbox/DropboxRepoActivity.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.text.TextUtils
+import android.text.method.HideReturnsTransformationMethod
+import android.text.method.PasswordTransformationMethod
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.EditText
@@ -30,6 +32,7 @@ import com.orgzly.android.util.LogUtils
 import com.orgzly.android.util.MiscUtils
 import com.orgzly.android.util.UriUtils
 import com.orgzly.databinding.ActivityRepoDropboxBinding
+import kotlinx.android.synthetic.main.activity_repo_dropbox.view.*
 import javax.inject.Inject
 
 
@@ -90,6 +93,12 @@ class DropboxRepoActivity : CommonActivity() {
                 val path = Uri.parse(repoWithProps.repo.url).path
 
                 binding.activityRepoDropboxDirectory.setText(path)
+
+                val encryption = repoWithProps.props.get("pgpPassphrase")
+
+                encryption?.also {
+                    binding.activityRepoDropboxEncryptionPassphrase.setText(it)
+                }
             }
         }
 
@@ -202,6 +211,13 @@ class DropboxRepoActivity : CommonActivity() {
 
         val url = UriUtils.uriFromPath(DropboxRepo.SCHEME, directory).toString()
 
+        val propsMap = if (!binding.activityRepoDropboxEncryptionPassphrase.text.isNullOrEmpty()) {
+            val passphrase = binding.activityRepoDropboxEncryptionPassphrase.text.toString()
+            mapOf("pgpPassphrase" to passphrase)
+        } else {
+            emptyMap()
+        }
+
         val repo = try {
             viewModel.validate(RepoType.DROPBOX, url)
         } catch (e: Exception) {
@@ -211,7 +227,7 @@ class DropboxRepoActivity : CommonActivity() {
             return
         }
 
-        viewModel.saveRepo(RepoType.DROPBOX, repo.uri.toString())
+        viewModel.saveRepo(RepoType.DROPBOX, repo.uri.toString(), propsMap)
     }
 
     private fun toggleLinkAfterConfirmation() {

--- a/app/src/main/res/layout/activity_repo_dropbox.xml
+++ b/app/src/main/res/layout/activity_repo_dropbox.xml
@@ -24,6 +24,7 @@
                 tools:context=".android.ui.main.MainActivity">
 
                 <!-- Link/unlink button. -->
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -56,14 +57,40 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_between_content_areas"
                     app:errorEnabled="true">
+
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/activity_repo_dropbox_directory"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="text"
-                        android:imeOptions="actionDone"
+                        android:imeOptions="actionNext"
                         android:hint="@string/fragment_repo_dropbox_directory_desc" />
+
                 </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/activity_repo_dropbox_passphrase_input_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/space_between_content_areas"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/activity_repo_dropbox_encryption_passphrase"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textPassword"
+                        android:imeOptions="actionDone"
+                        android:hint="@string/fragment_repo_dropbox_encryption_passphrase_desc" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:id="@+id/textView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/space_between_content_areas"
+                    android:text="@string/fragment_repo_dropbox_encryption_desc" />
 
             </LinearLayout>
 
@@ -72,4 +99,5 @@
         <include layout="@layout/app_bar" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="searches">Searches</string>
     <string name="search">Search</string>
     <string name="new_search">New Search</string>
+    <string name="active">Active</string>
     <string name="no_repos">No repositories configured</string>
     <string name="multiple_repos">Multiple repositories exist</string>
 
@@ -193,6 +194,8 @@
 
     <string name="fragment_repo_dropbox_directory_desc">Directory inside Dropbox (e.g. “/Documents/Orgzly”)</string>
     <string name="directory_uri">Directory URI</string>
+    <string name="fragment_repo_dropbox_encryption_passphrase_desc">Enter a passphrase to enable encryption</string>
+    <string name="fragment_repo_dropbox_encryption_desc">The contents of an existing repository should be cleared before changing the passphrase or enabling encryption. Changing the passphrase does not automatically re-encrypt remote notebooks. Enabling encryption will create new files in the repository with extension “.org.gpg”, existing unencrypted files with extension “.org” are not automatically deleted.</string>
 
     <string name="git_url_hint">Remote address (e.g. git@github.com:orgzly/orgzly-android.git)</string>
     <string name="git_directory_hint">Directory location (e.g. “file:/sdcard/orgzly”)</string>


### PR DESCRIPTION
Here is an initial implementation of encrypted notebook sync! Only encrypted files are sent to the remote repository so that the unencrypted plaintext of the notebook never leaves the phone. See the discussion in #43. 

Current state of the feature:
- Notebooks are encrypted in the PGP format using the AES-256 symmetric encryption algorithm. 
- Encryption and decryption is done using the [bouncycastle OpenPGP API](https://mvnrepository.com/artifact/org.bouncycastle/bcpg-jdk15on). API usage Code is taken from [OpenKeychain](https://github.com/open-keychain/open-keychain) (also GPLv3) since at the moment they don't offer an API for symmetric encryption (there is an open bug open-keychain/open-keychain#2536).
- Encryption is enabled and password is configured individually for each sync repo.
- Currently there is a configuration UI for Dropbox repos.
- Encrypted repo files are identified by the file extension `.org.gpg`.

There are some issues with tricky sync situations where I would be grateful for guidance. Confusing behavior happens during loading of notebooks if the repo contains encrypted `.org.pgp` files and encryption is disabled the app; if the repo contains unencrypted `.org` files and encryption is enabled; if both `x.org` and `x.org.gpg` are present. Currently it is possible to toggle encryption or change the password for an existing repo, allowing for these cases to happen. It also happens when adding a new repo pointing to an existing Dropbox path with these such present. Clearing of the repo and possibly re-encryption should never automatically be performed IMO (also not at the next sync).

From what I gather, in the save directly after toggling encryption, if at least one sync has taken place before, in `saveBookToRepo()` we get the wrong filename (for instance the old `x.org` instead of `x.org.gpg` when encryption was just toggled on), so I made sure the target filename suffix is corrected based on the encryption setting. In `loadBookFromRepo()` I think the filenames are originally from the `SyncRepo.getBooks()`, so it would maybe make sense to reject loading a file `x.org.gpg` (exception?) if encryption is disabled, and vice versa `x.org` if encryption is enabled. I will also have to do further investigation for the case where both `x.org` and `x.org.gpg` exist. @nevenz do you have any ideas how and where to best handle these cases?

Other issues (I am new to java/android):
- [ ] Should I intersperse more `BufferedInput/OutputStream` in the encryption routines?
- [ ] UI: In the dropbox repo layout, I suspect the `android:imeOptions="actionNext"` do not have the desired effect. When inputting into the directory textedit and then hitting the next (enter) button on the keyboard, the settings window closes, even though I think it should skip to the encryption textedit.
- [ ] which strings should be string resources?
- [ ] needs tests