### PR TITLE
Add Clocking / Time capture implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,8 @@ android {
                 ]
             }
         }
+
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildFeatures {

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -981,16 +981,13 @@ class DataRepository @Inject constructor(
         noteIds.forEach() { noteId ->
             val content = db.note().get(noteId)?.content
 
-            if(type == 0) {
+            if (type == 0) {
                 val newContent = OrgFormatter.clockIn(content)
                 db.note().updateContent(noteId, newContent)
-            }
-            else if(type == 1) {
+            } else if (type == 1) {
                 val newContent = OrgFormatter.clockOut(content)
                 db.note().updateContent(noteId, newContent)
-            }
-            else if(type == 2)
-            {
+            } else if (type == 2) {
                 val newContent = OrgFormatter.clockCancel(content)
                 db.note().updateContent(noteId, newContent)
             }
@@ -1839,7 +1836,11 @@ class DataRepository @Inject constructor(
 
         val startId = getOrgDateTimeId(range.startTime)
 
-        val rangeEndTime = if (range.endTime != null) { range.endTime } else { null }
+        val rangeEndTime = if (range.endTime != null) {
+            range.endTime
+        } else {
+            null
+        }
         val endId = if (rangeEndTime != null) getOrgDateTimeId(rangeEndTime) else null
 
         return db.orgRange().insert(OrgRange(0, str, startId, endId))

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -976,6 +976,31 @@ class DataRepository @Inject constructor(
         }
     }
 
+    fun setNotesClockingState(noteIds: Set<Long>, type: Int) {
+
+        noteIds.forEach() { noteId ->
+            val content = db.note().get(noteId)?.content
+
+            if(type == 0) {
+                val newContent = OrgFormatter.clockIn(content)
+                db.note().updateContent(noteId, newContent)
+            }
+            else if(type == 1) {
+                val newContent = OrgFormatter.clockOut(content)
+                db.note().updateContent(noteId, newContent)
+            }
+            else if(type == 2)
+            {
+                val newContent = OrgFormatter.clockCancel(content)
+                db.note().updateContent(noteId, newContent)
+            }
+        }
+
+        db.note().get(noteIds).mapTo(hashSetOf()) { it.position.bookId }.let {
+            updateBookIsModified(it, true)
+        }
+    }
+
     fun toggleNoteFoldedState(noteId: Long): Int {
         return db.runInTransaction(Callable {
             val note = db.note().get(noteId) ?: return@Callable 0

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -89,6 +89,7 @@ import com.orgzly.android.usecase.NoteUpdateDeadlineTime;
 import com.orgzly.android.usecase.NoteUpdateScheduledTime;
 import com.orgzly.android.usecase.NoteUpdateState;
 import com.orgzly.android.usecase.NoteUpdateStateToggle;
+import com.orgzly.android.usecase.NoteUpdateClockingState;
 import com.orgzly.android.usecase.SavedSearchCreate;
 import com.orgzly.android.usecase.SavedSearchDelete;
 import com.orgzly.android.usecase.SavedSearchExport;
@@ -828,6 +829,11 @@ public class MainActivity extends CommonActivity
     @Override
     public void onDeadlineTimeUpdateRequest(Set<Long> noteIds, OrgDateTime time) {
         mSyncFragment.run(new NoteUpdateDeadlineTime(noteIds, time));
+    }
+
+    @Override
+    public void onClockingUpdateRequest(Set<Long> noteIds, Integer type) {
+        mSyncFragment.run(new NoteUpdateClockingState(noteIds, type));
     }
 
     @Override /* BookFragment */

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -831,11 +831,6 @@ public class MainActivity extends CommonActivity
         mSyncFragment.run(new NoteUpdateDeadlineTime(noteIds, time));
     }
 
-    @Override
-    public void onClockingUpdateRequest(Set<Long> noteIds, Integer type) {
-        mSyncFragment.run(new NoteUpdateClockingState(noteIds, type));
-    }
-
     @Override /* BookFragment */
     public void onBookPrefaceEditRequest(Book book) {
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG);

--- a/app/src/main/java/com/orgzly/android/ui/main/SharedMainActivityViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/main/SharedMainActivityViewModel.kt
@@ -2,6 +2,10 @@ package com.orgzly.android.ui.main
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.orgzly.android.App
+import com.orgzly.android.usecase.NoteUpdateClockingState
+import com.orgzly.android.usecase.UseCase
+import com.orgzly.android.usecase.UseCaseRunner
 
 class SharedMainActivityViewModel : ViewModel() {
     val drawerLockState: MutableLiveData<Boolean> = MutableLiveData()
@@ -22,6 +26,20 @@ class SharedMainActivityViewModel : ViewModel() {
             subTitle: CharSequence?,
             selectionCount: Int) {
         fragmentState.value = FragmentState(tag, title, subTitle, selectionCount)
+    }
+
+    fun run(action: UseCase?) {
+        App.EXECUTORS.diskIO().execute {
+            try {
+                UseCaseRunner.run(action!!)
+            } catch (e: Throwable) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    fun clockingUpdateRequest(noteIds: Set<Long>, type: Int) {
+        run(NoteUpdateClockingState(noteIds, type))
     }
 
     data class FragmentState(

--- a/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
@@ -171,7 +171,7 @@ abstract class NotesFragment : Fragment(), TimestampDialogFragment.OnDateTimeSet
 
         fun onScheduledTimeUpdateRequest(noteIds: Set<Long>, time: OrgDateTime?)
         fun onDeadlineTimeUpdateRequest(noteIds: Set<Long>, time: OrgDateTime?)
-
+        fun onClockingUpdateRequest(noteIds: Set<Long>, type: Int?)
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
@@ -171,7 +171,6 @@ abstract class NotesFragment : Fragment(), TimestampDialogFragment.OnDateTimeSet
 
         fun onScheduledTimeUpdateRequest(noteIds: Set<Long>, time: OrgDateTime?)
         fun onDeadlineTimeUpdateRequest(noteIds: Set<Long>, time: OrgDateTime?)
-        fun onClockingUpdateRequest(noteIds: Set<Long>, type: Int?)
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
@@ -655,6 +655,13 @@ class BookFragment :
             in deadlineTimeButtonIds() ->
                 displayTimestampDialog(actionId, ids)
 
+            R.id.quick_bar_clock_in ->
+                listener?.onClockingUpdateRequest(ids, 0)
+            R.id.quick_bar_clock_out ->
+                listener?.onClockingUpdateRequest(ids, 1)
+            R.id.quick_bar_clock_cancel ->
+                listener?.onClockingUpdateRequest(ids, 2)
+
             R.id.quick_bar_delete,
             R.id.book_cab_delete_note -> {
                 delete(ids)

--- a/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
@@ -656,11 +656,11 @@ class BookFragment :
                 displayTimestampDialog(actionId, ids)
 
             R.id.quick_bar_clock_in ->
-                listener?.onClockingUpdateRequest(ids, 0)
+                sharedMainActivityViewModel.clockingUpdateRequest(ids, 0)
             R.id.quick_bar_clock_out ->
-                listener?.onClockingUpdateRequest(ids, 1)
+                sharedMainActivityViewModel.clockingUpdateRequest(ids, 1)
             R.id.quick_bar_clock_cancel ->
-                listener?.onClockingUpdateRequest(ids, 2)
+                sharedMainActivityViewModel.clockingUpdateRequest(ids, 2)
 
             R.id.quick_bar_delete,
             R.id.book_cab_delete_note -> {

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
@@ -123,11 +123,11 @@ abstract class QueryFragment :
                 displayTimestampDialog(R.id.bottom_action_bar_deadline, ids)
 
             R.id.quick_bar_clock_in ->
-                listener?.onClockingUpdateRequest(ids, 0)
+                sharedMainActivityViewModel.clockingUpdateRequest(ids, 0)
             R.id.quick_bar_clock_out ->
-                listener?.onClockingUpdateRequest(ids, 1)
+                sharedMainActivityViewModel.clockingUpdateRequest(ids, 1)
             R.id.quick_bar_clock_cancel ->
-                listener?.onClockingUpdateRequest(ids, 2)
+                sharedMainActivityViewModel.clockingUpdateRequest(ids, 2)
 
             R.id.quick_bar_state,
             R.id.bottom_action_bar_state ->

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
@@ -122,6 +122,13 @@ abstract class QueryFragment :
             R.id.bottom_action_bar_deadline ->
                 displayTimestampDialog(R.id.bottom_action_bar_deadline, ids)
 
+            R.id.quick_bar_clock_in ->
+                listener?.onClockingUpdateRequest(ids, 0)
+            R.id.quick_bar_clock_out ->
+                listener?.onClockingUpdateRequest(ids, 1)
+            R.id.quick_bar_clock_cancel ->
+                listener?.onClockingUpdateRequest(ids, 2)
+
             R.id.quick_bar_state,
             R.id.bottom_action_bar_state ->
                 listener?.let {

--- a/app/src/main/java/com/orgzly/android/ui/notes/quickbar/QuickBar.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/quickbar/QuickBar.kt
@@ -165,9 +165,9 @@ class QuickBar(val context: Context, val inBook: Boolean) {
                     Button(R.id.quick_bar_deadline, R.styleable.Icons_ic_alarm_24dp),
                     Button(R.id.quick_bar_state, R.styleable.Icons_ic_flag_24dp),
                     Button(R.id.quick_bar_done, R.styleable.Icons_ic_outline_check_circle_24dp),
-                    Button(R.id.quick_bar_clock_in, R.styleable.Icons_ic_alarm_24dp),
-                    Button(R.id.quick_bar_clock_out, R.styleable.Icons_ic_alarm_24dp),
-                    Button(R.id.quick_bar_clock_cancel, R.styleable.Icons_ic_alarm_24dp)
+                    Button(R.id.quick_bar_clock_in, R.styleable.Icons_ic_hourglass_top),
+                    Button(R.id.quick_bar_clock_out, R.styleable.Icons_ic_hourglass_bottom),
+                    Button(R.id.quick_bar_clock_cancel, R.styleable.Icons_ic_hourglass_disabled)
             )
 
             private val LEFT_IN_BOOK = listOf(

--- a/app/src/main/java/com/orgzly/android/ui/notes/quickbar/QuickBar.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/quickbar/QuickBar.kt
@@ -164,7 +164,10 @@ class QuickBar(val context: Context, val inBook: Boolean) {
                     Button(R.id.quick_bar_schedule, R.styleable.Icons_ic_today_24dp),
                     Button(R.id.quick_bar_deadline, R.styleable.Icons_ic_alarm_24dp),
                     Button(R.id.quick_bar_state, R.styleable.Icons_ic_flag_24dp),
-                    Button(R.id.quick_bar_done, R.styleable.Icons_ic_outline_check_circle_24dp)
+                    Button(R.id.quick_bar_done, R.styleable.Icons_ic_outline_check_circle_24dp),
+                    Button(R.id.quick_bar_clock_in, R.styleable.Icons_ic_alarm_24dp),
+                    Button(R.id.quick_bar_clock_out, R.styleable.Icons_ic_alarm_24dp),
+                    Button(R.id.quick_bar_clock_cancel, R.styleable.Icons_ic_alarm_24dp)
             )
 
             private val LEFT_IN_BOOK = listOf(

--- a/app/src/main/java/com/orgzly/android/usecase/NoteUpdateClockingState.kt
+++ b/app/src/main/java/com/orgzly/android/usecase/NoteUpdateClockingState.kt
@@ -1,0 +1,15 @@
+package com.orgzly.android.usecase
+
+import com.orgzly.android.data.DataRepository
+import com.orgzly.org.datetime.OrgDateTime
+
+class NoteUpdateClockingState(val noteIds: Set<Long>, val type: Int) : UseCase() {
+    override fun run(dataRepository: DataRepository): UseCaseResult {
+        dataRepository.setNotesClockingState(noteIds, type)
+
+        return UseCaseResult(
+                modifiesLocalData = true,
+                triggersSync = SYNC_DATA_MODIFIED
+        )
+    }
+}

--- a/app/src/main/java/com/orgzly/android/usecase/NoteUpdateClockingState.kt
+++ b/app/src/main/java/com/orgzly/android/usecase/NoteUpdateClockingState.kt
@@ -1,7 +1,6 @@
 package com.orgzly.android.usecase
 
 import com.orgzly.android.data.DataRepository
-import com.orgzly.org.datetime.OrgDateTime
 
 class NoteUpdateClockingState(val noteIds: Set<Long>, val type: Int) : UseCase() {
     override fun run(dataRepository: DataRepository): UseCaseResult {

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -387,26 +387,17 @@ object OrgFormatter {
         return ":$LOGBOOK_DRAWER_NAME:\n$entry\n:END:$prefixedContent"
     }
 
-    private fun getLastClockInPosition(content: String): ArrayList<Int> {
-        val m = LOGBOOK_DRAWER_PATTERN.matcher(content)
-
+    private fun getLastClockInPosition(logbookContent: String): ArrayList<Int> {
         val pos = ArrayList<Int>()
 
-        if (m.find()) {
-            val start = m.start(2) // Content start
-            val end = m.end()
-
-            val m2 = CLOCKED_TIMES_P.matcher(content.subSequence(start, end))
-            while (m2.find()) {
-
-                // Check if we have one entry without clock-out
-                if (m2.group(3).isNullOrEmpty()) {
-                    pos.add(m2.start(1))
-                    pos.add(m2.end(1))
-                    break
-                }
+        val m = CLOCKED_TIMES_P.matcher(logbookContent)
+        while (m.find()) {
+            // Check if we have one entry without clock-out
+            if (m.group(3).isNullOrEmpty()) {
+                pos.add(m.start(1))
+                pos.add(m.end(1))
+                break
             }
-
         }
 
         return pos
@@ -423,7 +414,8 @@ object OrgFormatter {
             val m = LOGBOOK_DRAWER_PATTERN.matcher(content)
 
             if (m.find()) {
-                val pos = getLastClockInPosition(content)
+                val logbookContent = content.substring(m.start(2), m.end(2))
+                val pos = getLastClockInPosition(logbookContent)
 
                 // If we cannot find an already clocked entry, we add one
                 if(pos.isEmpty()) {
@@ -450,12 +442,13 @@ object OrgFormatter {
             val m = LOGBOOK_DRAWER_PATTERN.matcher(content)
 
             if (m.find()) {
-                val pos = getLastClockInPosition(content)
+                val logbookContent = content.substring(m.start(2), m.end(2))
+                val pos = getLastClockInPosition(logbookContent)
 
                 // If we find an already clocked entry, we clock-out
                 if(pos.isNotEmpty()) {
                     // Find the timestamp to compute the difference
-                    val m2 = Pattern.compile(INACTIVE_DATETIME).matcher(content)
+                    val m2 = Pattern.compile(INACTIVE_DATETIME).matcher(logbookContent.substring(pos[0], pos[1]))
 
                     if (m2.find()) {
                         val clock_in = OrgDateTime.parseOrNull(m2.group(1))
@@ -503,7 +496,8 @@ object OrgFormatter {
             val m = LOGBOOK_DRAWER_PATTERN.matcher(content)
 
             if (m.find()) {
-                val pos = getLastClockInPosition(content)
+                val logbookContent = content.substring(m.start(2), m.end(2))
+                val pos = getLastClockInPosition(logbookContent)
 
                 // If we find an already clocked entry, we cancel it
                 if(pos.isNotEmpty()) {

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -55,7 +55,8 @@ object OrgFormatter {
     private const val PLAIN_LIST_CHARS = "-\\+"
     private val CHECKBOXES_PATTERN = Pattern.compile("""^\s*[$PLAIN_LIST_CHARS]\s+(\[[ X]])""", Pattern.MULTILINE)
 
-    private val INACTIVE_DATETIME ="(\\[[0-9]{4,}-[0-9]{2}-[0-9]{2} +[A-Za-z\\.]* +[0-9]{1,2}:[0-9]{2}\\])"
+    private val INACTIVE_DATETIME = "(\\[[0-9]{4,}-[0-9]{2}-[0-9]{2} ?[^\\]\\r\\n>]*?[0-9]{1,2}:[0-9]{2}\\])"
+    private val CLOCKED_TIMES_P = Pattern.compile("(CLOCK: *$INACTIVE_DATETIME) *(-- *$INACTIVE_DATETIME)?( *=> *[0-9]{1,4}:[0-9]{2})?[\\r\\n]*")
 
     private const val FLAGS = Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 
@@ -386,8 +387,7 @@ object OrgFormatter {
         return ":$LOGBOOK_DRAWER_NAME:\n$entry\n:END:$prefixedContent"
     }
 
-    @JvmStatic
-    fun getLastClockInPosition(content: String?): ArrayList<Int> {
+    private fun getLastClockInPosition(content: String): ArrayList<Int> {
         val m = LOGBOOK_DRAWER_PATTERN.matcher(content)
 
         val pos = ArrayList<Int>()
@@ -396,9 +396,7 @@ object OrgFormatter {
             val start = m.start(2) // Content start
             val end = m.end()
 
-            val CLOCKED_TIMES_P = Pattern.compile("(CLOCK: *$INACTIVE_DATETIME) *(-- *$INACTIVE_DATETIME)?( *=> *[0-9]{1,4}:[0-9]{2})?[\\r\\n]*")
-
-            val m2 = CLOCKED_TIMES_P.matcher(content?.subSequence(start, end))
+            val m2 = CLOCKED_TIMES_P.matcher(content.subSequence(start, end))
             while (m2.find()) {
 
                 // Check if we have one entry without clock-out

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -501,7 +501,17 @@ object OrgFormatter {
 
                 // If we find an already clocked entry, we cancel it
                 if(pos.isNotEmpty()) {
-                    StringBuilder(content).delete(m.start(2) + pos[0], m.start(2) + pos[1] + 1).toString()
+                    val updatedContent = StringBuilder(content).delete(m.start(2) + pos[0], m.start(2) + pos[1] + 1).toString()
+
+                    // If the LOGBOOK ends up being empty
+                    // We delete it like Org would do
+                    val endPos = updatedContent.indexOf(":END:", m.start(2))
+                    if( endPos == (m.start(2)) ) {
+                        StringBuilder(updatedContent).delete(m.start(0), m.start(0) + endPos + ":END:".length + 2).toString()
+                    }
+                    else {
+                        updatedContent
+                    }
                 }
                 // Otherwise, we just return the original content
                 else {

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -55,7 +55,7 @@ object OrgFormatter {
     private const val PLAIN_LIST_CHARS = "-\\+"
     private val CHECKBOXES_PATTERN = Pattern.compile("""^\s*[$PLAIN_LIST_CHARS]\s+(\[[ X]])""", Pattern.MULTILINE)
 
-    private val FULL_TIMESTAMP ="([\\[<][0-9]{4,}-[0-9]{2}-[0-9]{2} +[A-Za-z\\.]* +[0-9]{1,2}:[0-9]{2}[\\]>])"
+    private val INACTIVE_DATETIME ="(\\[[0-9]{4,}-[0-9]{2}-[0-9]{2} +[A-Za-z\\.]* +[0-9]{1,2}:[0-9]{2}\\])"
 
     private const val FLAGS = Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 
@@ -396,7 +396,7 @@ object OrgFormatter {
             val start = m.start(2) // Content start
             val end = m.end()
 
-            val CLOCKED_TIMES_P = Pattern.compile("(CLOCK: *" + FULL_TIMESTAMP + ") *(-- *" + FULL_TIMESTAMP + ")?( *=> *[0-9]{1,4}:[0-9]{2})?[\\r\\n]*")
+            val CLOCKED_TIMES_P = Pattern.compile("(CLOCK: *$INACTIVE_DATETIME) *(-- *$INACTIVE_DATETIME)?( *=> *[0-9]{1,4}:[0-9]{2})?[\\r\\n]*")
 
             val m2 = CLOCKED_TIMES_P.matcher(content?.subSequence(start, end))
             while (m2.find()) {
@@ -457,7 +457,7 @@ object OrgFormatter {
                 // If we find an already clocked entry, we clock-out
                 if(pos.isNotEmpty()) {
                     // Find the timestamp to compute the difference
-                    val m2 = Pattern.compile(FULL_TIMESTAMP).matcher(content)
+                    val m2 = Pattern.compile(INACTIVE_DATETIME).matcher(content)
 
                     if (m2.find()) {
                         val clock_in = OrgDateTime.parseOrNull(m2.group(1))

--- a/app/src/main/res/drawable/ic_hourglass_bottom.xml
+++ b/app/src/main/res/drawable/ic_hourglass_bottom.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24" >
+  <path
+      android:fillColor="?attr/text_primary_color"
+      android:pathData="M18,22l-0.01,-6L14,12l3.99,-4.01L18,2H6v6l4,4l-4,3.99V22H18zM8,7.5V4h8v3.5l-4,4L8,7.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_hourglass_disabled.xml
+++ b/app/src/main/res/drawable/ic_hourglass_disabled.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="?attr/text_primary_color"
+      android:pathData="M8,4l8,0l0,3.5l-2.84,2.84l1.25,1.25l3.59,-3.58l-0.01,-0.01l0.01,0l0,-6l-12,0l0,1.17l2,2z"/>
+  <path
+      android:fillColor="?attr/text_primary_color"
+      android:pathData="M2.1,2.1L0.69,3.51l8.9,8.9L6,16l0.01,0.01H6V22h12v-1.17l2.49,2.49l1.41,-1.41L2.1,2.1zM16,20H8v-3.5l2.84,-2.84L16,18.83V20z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_hourglass_top.xml
+++ b/app/src/main/res/drawable/ic_hourglass_top.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="?attr/text_primary_color"
+      android:pathData="M6,2l0.01,6L10,12l-3.99,4.01L6,22h12v-6l-4,-4l4,-3.99V2H6zM16,16.5V20H8v-3.5l4,-4L16,16.5z"/>
+</vector>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -113,6 +113,9 @@
         <attr name="ic_folder_open_24dp" format="reference"/>
         <attr name="ic_folder_open_48dp" format="reference"/>
         <attr name="ic_format_list_bulleted_18dp" format="reference"/>
+        <attr name="ic_hourglass_top" format="reference"/>
+        <attr name="ic_hourglass_bottom" format="reference"/>
+        <attr name="ic_hourglass_disabled" format="reference"/>
         <attr name="ic_info_outline_18dp" format="reference"/>
         <attr name="ic_info_outline_24dp" format="reference"/>
         <attr name="ic_insert_drive_file_24dp" format="reference"/>

--- a/app/src/main/res/values/quick_bar_ids.xml
+++ b/app/src/main/res/values/quick_bar_ids.xml
@@ -12,4 +12,7 @@
     <item type="id" name="quick_bar_refile" />
     <item type="id" name="quick_bar_open" />
     <item type="id" name="quick_bar_focus" />
+    <item type="id" name="quick_bar_clock_in" />
+    <item type="id" name="quick_bar_clock_out" />
+    <item type="id" name="quick_bar_clock_cancel" />
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -135,6 +135,9 @@
         <item name="ic_folder_open_48dp">@drawable/ic_folder_open_black_48dp</item>
         <item name="ic_format_list_bulleted_18dp">@drawable/ic_format_list_bulleted_black_18dp</item>
         <item name="ic_info_outline_18dp">@drawable/ic_info_outline_black_18dp</item>
+        <item name="ic_hourglass_top">@drawable/ic_hourglass_top</item>
+        <item name="ic_hourglass_bottom">@drawable/ic_hourglass_bottom</item>
+        <item name="ic_hourglass_disabled">@drawable/ic_hourglass_disabled</item>
         <item name="ic_info_outline_24dp">@drawable/ic_info_outline_black_24dp</item>
         <item name="ic_insert_drive_file_24dp">@drawable/ic_insert_drive_file_black_24dp</item>
         <item name="ic_keyboard_arrow_down_24dp">@drawable/ic_keyboard_arrow_down_black_24dp</item>
@@ -305,6 +308,9 @@
         <item name="ic_folder_open_24dp">@drawable/ic_folder_open_white_24dp</item>
         <item name="ic_folder_open_48dp">@drawable/ic_folder_open_white_48dp</item>
         <item name="ic_format_list_bulleted_18dp">@drawable/ic_format_list_bulleted_white_18dp</item>
+        <item name="ic_hourglass_top">@drawable/ic_hourglass_top</item>
+        <item name="ic_hourglass_bottom">@drawable/ic_hourglass_bottom</item>
+        <item name="ic_hourglass_disabled">@drawable/ic_hourglass_disabled</item>
         <item name="ic_info_outline_18dp">@drawable/ic_info_outline_white_18dp</item>
         <item name="ic_info_outline_24dp">@drawable/ic_info_outline_white_24dp</item>
         <item name="ic_insert_drive_file_24dp">@drawable/ic_insert_drive_file_white_24dp</item>


### PR DESCRIPTION
Hello,

This PR should fix #15. The basic functionalities should be covered.
What is implemented:
- [x] Quickbar (Book and Query) buttons to clock-{in,out,cancel}
- [x] Clocking logic handling in OrgFormatter
  - [x] Allow to clock-in, only if a previous clocked-in entry is not already present
  - [x] Allow to clock-out, only if a previous clocked-in entry is present, and compute the spent time 
  - [x] Allow to cancel the latest clock

What remains to be fixed:
- [x] Buttons for clock-{in,out,cancel} are currently the same alarm icon
  - Maybe having a clock icon with an arrow going in for clock-in, a clock icon with with an arrow going out for clock-out and a button with the strikethrough clock for org-cancel ?
  => using the hourglass_{top, bottom, disabled} material icons
- [ ] The regexes in OrgFormatter might be moved to OrgPatterns
- [ ] Kotlin code needs some improvement, as I do not have much experience in it
- [ ] Maybe adding buttons in the note edition UI to clock-{in,out,cancel} ?

Thanks for your comments and suggestions for improvements !