### PR TITLE
Recognize + as valid bullet symbol for unordered lists

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/views/EditTextWithMarkup.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/EditTextWithMarkup.kt
@@ -36,7 +36,9 @@ class EditTextWithMarkup : AppCompatEditText {
         // TODO: Remove space at the end of bullet
         private val listItemTypes = arrayOf(
                 ListItem(Pattern.compile("^(\\s*)-\\s+\\[[ X]](.*)"), "- [ ] "),
-                ListItem(Pattern.compile("^(\\s*)-(.*)"), "- ")
+                ListItem(Pattern.compile("^(\\s*)-(.*)"), "- "),
+                ListItem(Pattern.compile("^(\\s*)\\+\\s+\\[[ X]](.*)"), "+ [ ] "),
+                ListItem(Pattern.compile("^(\\s*)\\+(.*)"), "+ ")
         )
 
         private var currentListItem : CurrentListItem? = null

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -51,7 +51,8 @@ object OrgFormatter {
 
     private val LOGBOOK_DRAWER_PATTERN = drawerPattern(LOGBOOK_DRAWER_NAME)
 
-    private val CHECKBOXES_PATTERN = Pattern.compile("""^\s*-\s+(\[[ X]])""", Pattern.MULTILINE)
+    private const val PLAIN_LIST_CHARS = "-\\+"
+    private val CHECKBOXES_PATTERN = Pattern.compile("""^\s*[$PLAIN_LIST_CHARS]\s+(\[[ X]])""", Pattern.MULTILINE)
 
     private const val FLAGS = Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 


### PR DESCRIPTION
**Description**: 
Make Orgzly recognize `+` as a valid bullet symbol for unordered lists  
   
**Implemented**:
  * [X] Add `+` as valid bullet symbols for unordered list items and plain list items with checkboxes

**References**: 
  * [Org-Mode: Plain Lists](https://www.gnu.org/software/emacs/manual/html_node/org/Plain-lists.html)
  * 8e0493725b116d34004ba8dbd454bd49cdd5d033: Recognizing `-` as valid bullet for plain list item

Resolves #558