### PR TITLE
Support relative links to headers inside notebooks

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -41,6 +41,7 @@ import com.orgzly.android.db.NotesClipboard;
 import com.orgzly.android.db.dao.NoteDao;
 import com.orgzly.android.db.entity.Book;
 import com.orgzly.android.db.entity.Note;
+import com.orgzly.android.db.entity.NoteView;
 import com.orgzly.android.db.entity.Repo;
 import com.orgzly.android.db.entity.SavedSearch;
 import com.orgzly.android.prefs.AppPreferences;
@@ -112,6 +113,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Set;
+
+import kotlin.Pair;
 
 public class MainActivity extends CommonActivity
         implements
@@ -396,6 +399,15 @@ public class MainActivity extends CommonActivity
                 } else if (userData instanceof File) {
                     File file = (File) userData;
                     openFileIfExists(file);
+                }
+                else if (userData instanceof Pair) {
+                    if (((Pair) userData).getFirst() instanceof  Book && ((Pair) userData).getSecond() instanceof NoteView) {
+                        NoteView noteView = (NoteView) ((Pair) userData).getSecond();
+                        Intent intent = new Intent(AppIntent.ACTION_OPEN_NOTE);
+                        intent.putExtra(AppIntent.EXTRA_NOTE_ID, noteView.getNote().getId());
+                        intent.putExtra(AppIntent.EXTRA_BOOK_ID, ((Book) ((Pair) userData).getFirst()).getId());
+                        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+                    }
                 }
             }
         });

--- a/app/src/main/java/com/orgzly/android/usecase/LinkFindTarget.kt
+++ b/app/src/main/java/com/orgzly/android/usecase/LinkFindTarget.kt
@@ -29,12 +29,12 @@ class LinkFindTarget(val path: String) : UseCase() {
         }
     }
 
-    private fun isAbsolute(path: String): Boolean {
-        return path.startsWith('/')
+    private fun isAbsolute(bookPath: String): Boolean {
+        return bookPath.startsWith('/')
     }
 
-    private fun isMaybeBook(path: String): BookName? {
-        val file = File(path)
+    private fun isMaybeBook(bookPath: String): BookName? {
+        val file = File(bookPath)
 
         return if (!hasParent(file) && BookName.isSupportedFormatFileName(file.name)) {
             BookName.fromFileName(file.name)


### PR DESCRIPTION
Fixes #694 
Related to #565 

Now, if you click on the link "[[file:"notes.org::Heading1"][link]]" it opens the selected note (in "editing" mode).

Please help me patch up this frankenstein, I just learned about kotlin a week ago :)