### PR TITLE
Use only the internal cache directory for temporary book files

### DIFF
--- a/app/src/main/java/com/orgzly/android/LocalStorage.java
+++ b/app/src/main/java/com/orgzly/android/LocalStorage.java
@@ -47,10 +47,10 @@ public class LocalStorage {
     }
 
     public File getCacheDirectory(String child) throws IOException {
-        File dir = externalCacheDir(child);
+        File dir = internalCacheDir(child);
 
         if (dir == null) {
-            dir = internalCacheDir(child);
+            throw new IOException("Failed to get cache directory " + child);
         }
 
         return dir;
@@ -103,12 +103,12 @@ public class LocalStorage {
         }
     }
 
-    private File internalCacheDir(String dir) throws IOException {
+    private File internalCacheDir(String dir) {
         File file = new File(mContext.getCacheDir(), dir);
 
         if (! file.isDirectory()) {
             if (! file.mkdirs()) {
-                throw new IOException("Failed creating directory " + file);
+                return null;
             }
         }
 


### PR DESCRIPTION
Currently the external cache directory with a fallback to the internal one is used by Orgzly to store temporary book files when syncing. This directory resides on the primary shared/external storage which is accessible by all applications having READ_EXTERNAL_STORAGE permission. For extra context I am quoting the [documentation of Context.getExternalCacheDir()](https://developer.android.com/reference/android/content/Context.html#getExternalCacheDir()):

> There is no security enforced with these files. For example, any application holding Manifest.permission.WRITE_EXTERNAL_STORAGE can write to these files.

I am fairly certain that there are shady apps or just shady SDKs used by reputable apps that constantly monitor the shared storage for changes and analyze/filter/upload interesting data. There are mechanisms to notify an app if a file or folder is changed, see for example the "File Modified" event in Tasker, which can handle both, contrary to its name. I used that functionality as a proof-of-concept to grab a note while syncing.

This is a problem if one stores sensitive data in the notes, therefore I changed it to only use the internal cache directory. Apart from that, I performed a minor refactoring of the cache handler methods to be consistent in returning null vs throwing exceptions. I did not delete the external cache directory handler method yet.

Open questions:

1. Can the internal cache directory store a lot of data if someone has very large notes? I think yes, a cursory check on my device shows some apps using tens of megabytes of internal cache.

2. What to do if the internal cache directory handler method fails? Can it even fail? I think it only fails in catastrophic scenarios and can be safely relied on. It would also be counterproductive to fall back to the external cache directory without warning.

3. If someone is using directory-based repositories, the notes are saved to the shared storage by design. In this case, the user might very well be aware of and accept that other apps can read the notes, but it might be useful to present a (one-time?) warning about this situation when setting up a directory-based repository.