### PR TITLE
Git push over SSH only once per sync

### DIFF
--- a/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
+++ b/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
@@ -68,8 +68,12 @@ public class GitFileSynchronizer {
     }
 
     private void fetch() throws GitAPIException {
-        transportSetter().setTransport(git.fetch().setRemote(preferences.remoteName())).call();
-    }
+        transportSetter()
+                .setTransport(git.fetch()
+                        .setRemote(preferences.remoteName())
+                        .setRemoveDeletedRefs(true))
+                .call();
+}
 
     public void checkoutSelected() throws GitAPIException {
         git.checkout().setName(preferences.branchName()).call();

--- a/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
+++ b/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
@@ -11,6 +11,7 @@ import com.orgzly.android.repos.GitRepo;
 import com.orgzly.android.util.MiscUtils;
 
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.MergeResult;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.Status;
@@ -19,6 +20,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
@@ -27,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.List;
 import java.util.TimeZone;
 
 public class GitFileSynchronizer {
@@ -183,6 +186,45 @@ public class GitFileSynchronizer {
 
     public void tryPushIfUpdated(@NonNull RevCommit commit) throws IOException {
         if (!commit.equals(currentHead())) {
+            tryPush();
+        }
+    }
+
+    /**
+     * Try to push to remote if local and remote HEADs for the current branch
+     * point to different commits. This method was added to allow pushing only
+     * once per sync occasion: right after the "for namesake in namesakes"-loop
+     * in SyncService.doInBackground().
+     */
+    public void tryPushIfHeadDiffersFromRemote() {
+        String branchName = null;
+        String remoteName = null;
+        RevCommit localHead = null;
+        RevCommit remoteHead = null;
+        Repository repo = git.getRepository();
+
+        try {
+            branchName = repo.getBranch();
+            localHead = currentHead();
+            remoteName = preferences.remoteName();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        // If the current branch exists on the remote side, find out its HEAD commit.
+        try {
+            List<Ref> remoteBranches = git.branchList().setListMode(ListBranchCommand.ListMode.REMOTE).call();
+            for (Ref remoteBranch : remoteBranches) {
+                if (remoteBranch.getName().equals("refs/remotes/" + remoteName + "/" + branchName)) {
+                    remoteHead = getCommit(remoteName + "/" + branchName);
+                    break;
+                }
+            }
+        } catch (GitAPIException | IOException e) {
+            e.printStackTrace();
+        }
+
+        if (localHead != null && !localHead.equals(remoteHead)) {
             tryPush();
         }
     }

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -323,8 +323,6 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
                     synchronizer.getFileRevision(fileName, rookCommit),
                     rookCommit);
 
-            synchronizer.tryPushIfUpdated(rookCommit);
-
             syncBackNeeded = !synchronizer.fileMatchesInRevisions(
                     fileName, rookCommit, synchronizer.currentHead());
         } else {
@@ -339,5 +337,9 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
         return new TwoWaySyncResult(
                 currentVersionedRook(Uri.EMPTY.buildUpon().appendPath(fileName).build()),
                 writeBack);
+    }
+
+    public void tryPushIfHeadDiffersFromRemote() {
+        synchronizer.tryPushIfHeadDiffersFromRemote();
     }
 }

--- a/app/src/main/java/com/orgzly/android/repos/TwoWaySyncRepo.kt
+++ b/app/src/main/java/com/orgzly/android/repos/TwoWaySyncRepo.kt
@@ -7,4 +7,6 @@ import java.io.IOException
 interface TwoWaySyncRepo {
     @Throws(IOException::class)
     fun syncBook(uri: Uri, current: VersionedRook, fromDB: File): TwoWaySyncResult
+
+    fun tryPushIfHeadDiffersFromRemote()
 }

--- a/app/src/main/java/com/orgzly/android/sync/SyncService.kt
+++ b/app/src/main/java/com/orgzly/android/sync/SyncService.kt
@@ -316,6 +316,12 @@ class SyncService : Service() {
                 curr++
             }
 
+            for (repo in repos) {
+                if (repo is TwoWaySyncRepo) {
+                    repo.tryPushIfHeadDiffersFromRemote()
+                }
+            }
+
             syncStatus.set(SyncStatus.Type.FINISHED, null, 0, 0)
             announceActiveSyncStatus()
 


### PR DESCRIPTION
The rationale behind this is that I have found Git syncing multiple notebooks over SSH to be very slow. I realized that separate SSH sessions were being initiated for each updated notebook.

I believe there is no reason to initiate more than two SSH sessions: one for fetch the repo, and one for pushing it after all commits have been made.