### PR TITLE
Add two settings to configure relative path for file links.

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -633,6 +633,25 @@ public class AppPreferences {
     }
 
     /*
+     * File relative path.
+     */
+
+    /** Root for file:/xxx links */
+    public static String fileAbsoluteRoot(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_file_absolute_root),
+                context.getResources().getString(R.string.pref_default_file_absolute_root));
+    }
+
+    /** Root for file:xxx links */
+    public static String fileRelativeRoot(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_file_relative_root),
+                Environment.getExternalStorageDirectory().getPath()
+        );
+    }
+
+    /*
      * Note's metadata visibility
      */
 

--- a/app/src/main/java/com/orgzly/android/ui/ImageLoader.kt
+++ b/app/src/main/java/com/orgzly/android/ui/ImageLoader.kt
@@ -24,6 +24,8 @@ import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
 import com.bumptech.glide.request.RequestOptions
 import com.orgzly.R
+import com.orgzly.android.usecase.LinkFindTarget
+import com.orgzly.android.usecase.UseCaseRunner
 import com.orgzly.android.util.LogUtils
 
 
@@ -52,11 +54,11 @@ object ImageLoader {
             // Get the current context
             val context = App.getAppContext()
 
-            // Get the file
-            val file = if (path.startsWith('/')) {
-                File(path)
-            } else {
-                File(Environment.getExternalStorageDirectory(), path)
+            val file = UseCaseRunner.run(LinkFindTarget(path)).userData
+
+            if (file !is File) {
+                if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, "Did not find a File target for $path, actually found $file")
+                return
             }
 
             if (file.exists()) {

--- a/app/src/main/java/com/orgzly/android/usecase/LinkFindTarget.kt
+++ b/app/src/main/java/com/orgzly/android/usecase/LinkFindTarget.kt
@@ -1,11 +1,14 @@
 package com.orgzly.android.usecase
 
-import android.os.Environment
+import com.orgzly.android.App
 import com.orgzly.android.BookName
 import com.orgzly.android.data.DataRepository
+import com.orgzly.android.prefs.AppPreferences
 import java.io.File
 
 class LinkFindTarget(val path: String) : UseCase() {
+    val context = App.getAppContext();
+
     override fun run(dataRepository: DataRepository): UseCaseResult {
         val target = openLink(dataRepository, path)
 
@@ -16,8 +19,7 @@ class LinkFindTarget(val path: String) : UseCase() {
 
     private fun openLink(dataRepository: DataRepository, path: String): Any {
         return if (isAbsolute(path)) {
-            File(path)
-
+            File(AppPreferences.fileAbsoluteRoot(context), path)
         } else {
             isMaybeBook(path)?.let { bookName ->
                 dataRepository.getBook(bookName.name)?.let {
@@ -25,7 +27,7 @@ class LinkFindTarget(val path: String) : UseCase() {
                 }
             }
 
-            File(Environment.getExternalStorageDirectory(), path)
+            File(AppPreferences.fileRelativeRoot(context), path)
         }
     }
 

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -440,6 +440,11 @@
     <string name="pref_key_images_scale_down_to_width_value" translatable="false">pref_key_set_images_fixed_width_value</string>
     <string name="pref_default_images_scale_down_to_width_value" translatable="false">256</string>
 
+    <string name="pref_key_file_absolute_root">pref_key_file_absolute_root</string>
+    <string name="pref_default_file_absolute_root">/</string>
+
+    <string name="pref_key_file_relative_root">pref_key_file_relative_root</string>
+
     <!-- Separate notes with an empty line -->
     <string name="pref_key_separate_notes_with_new_line" translatable="false">pref_key_separate_notes_with_new_line</string>
     <string name="pref_default_separate_notes_with_new_line" translatable="false">@string/pref_value_separate_notes_with_new_line_multi_line_notes_only</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -620,6 +620,9 @@
     <string name="scale_down_to_width">Scale down to width</string>
     <string name="scale_down_to_width_summary">Scale down image to specified width</string>
 
+    <string name="file_absolute_root">Relative path for "file:/"</string>
+    <string name="file_relative_root">Relative path for "file:"</string>
+
     <string name="argument_used">%s used</string>
     <string name="argument_detected">%s detected</string>
     <string name="argument_selected">%s selected</string>

--- a/app/src/main/res/xml/prefs_screen_notebooks.xml
+++ b/app/src/main/res/xml/prefs_screen_notebooks.xml
@@ -230,5 +230,23 @@
             android:defaultValue="@string/pref_default_images_scale_down_to_width_value"
             app:min="1"
             android:dependency="@string/pref_key_images_scale_down_to_width"/>
+
+        <EditTextPreference
+            android:key="@string/pref_key_file_absolute_root"
+            android:title="@string/file_absolute_root"
+            android:selectAllOnFocus="false"
+            android:inputType="text"
+            android:maxLines="1"
+            android:defaultValue="@string/pref_default_file_absolute_root"
+            app:useSimpleSummaryProvider="true"/>
+
+        <EditTextPreference
+            android:key="@string/pref_key_file_relative_root"
+            android:title="@string/file_relative_root"
+            android:selectAllOnFocus="false"
+            android:inputType="text"
+            android:maxLines="1"
+            app:useSimpleSummaryProvider="true"/>
+
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Addresses #496 

Current behavior was
- `file:/xxx` relative to root.
- `file:xxx` relative to Environment.getExternalStorageDirectory().getPath().

The new behavior in this commit is:
- `file:/xxx` relative to pref AppPreferences#fileAbsoluteRoot(), default to "/" 
- `file:xxx` relative to pref AppPreferences#fileRelativeRoot(), default to Environment.getExternalStorageDirectory().getPath()

Added two basic settings in the Image category for these two prefs. The setting is text only, could potentially be directoyr picker.

The path following behavior is changed in `ImageLoader` and `Widget.followLinkToFile`, now both uses `LinkFindTarget`.