### PR TITLE
Git: Useful merge branches

### DIFF
--- a/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
+++ b/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
@@ -7,7 +7,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import com.orgzly.android.App;
-import com.orgzly.android.repos.GitRepo;
 import com.orgzly.android.util.MiscUtils;
 
 import org.eclipse.jgit.api.Git;
@@ -32,8 +31,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
 import java.util.TimeZone;
-
-import kotlin.io.FileAlreadyExistsException;
 
 public class GitFileSynchronizer {
     private static String TAG = GitFileSynchronizer.class.getSimpleName();
@@ -76,7 +73,7 @@ public class GitFileSynchronizer {
                         .setRemote(preferences.remoteName())
                         .setRemoveDeletedRefs(true))
                 .call();
-}
+    }
 
     public void checkoutSelected() throws GitAPIException {
         git.checkout().setName(preferences.branchName()).call();

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -9,7 +9,6 @@ import com.orgzly.android.db.entity.Repo;
 import com.orgzly.android.git.GitFileSynchronizer;
 import com.orgzly.android.git.GitPreferences;
 import com.orgzly.android.git.GitPreferencesFromRepoPrefs;
-import com.orgzly.android.git.GitSSHKeyTransportSetter;
 import com.orgzly.android.git.GitTransportSetter;
 import com.orgzly.android.prefs.RepoPreferences;
 

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -325,17 +325,25 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
     public TwoWaySyncResult syncBook(
             Uri uri, VersionedRook current, File fromDB) throws IOException {
         File writeBack = null;
+        boolean onMainBranch = true;
         String fileName = uri.getPath();
         if (fileName.startsWith("/"))
             fileName = fileName.replaceFirst("/", "");
-        boolean syncBackNeeded = false;
+        boolean syncBackNeeded;
         if (current != null) {
             RevCommit rookCommit = getCommitFromRevisionString(current.getRevision());
             Log.i("Git", String.format("File name %s, rookCommit: %s", fileName, rookCommit));
-            synchronizer.updateAndCommitFileFromRevisionAndMerge(
+            boolean merged = synchronizer.updateAndCommitFileFromRevisionAndMerge(
                     fromDB, fileName,
                     synchronizer.getFileRevision(fileName, rookCommit),
                     rookCommit);
+
+            // We have attempted a merge. Are we back on the main branch, or still on a temp branch?
+            onMainBranch = git.getRepository().getBranch().equals(preferences.branchName());
+
+            if (merged && !onMainBranch) {
+                onMainBranch = synchronizer.attemptReturnToMainBranch();
+            }
 
             syncBackNeeded = !synchronizer.fileMatchesInRevisions(
                     fileName, rookCommit, synchronizer.currentHead());
@@ -349,7 +357,7 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
             writeBack = synchronizer.repoDirectoryFile(fileName);
         }
         return new TwoWaySyncResult(
-                currentVersionedRook(Uri.EMPTY.buildUpon().appendPath(fileName).build()),
+                currentVersionedRook(Uri.EMPTY.buildUpon().appendPath(fileName).build()), onMainBranch,
                 writeBack);
     }
 

--- a/app/src/main/java/com/orgzly/android/repos/TwoWaySyncResult.kt
+++ b/app/src/main/java/com/orgzly/android/repos/TwoWaySyncResult.kt
@@ -1,5 +1,7 @@
 package com.orgzly.android.repos
 
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
 import java.io.File
 
 /**
@@ -8,7 +10,9 @@ import java.io.File
  * @param loadFile This file contains the new data that should be loaded to the local notebook that
  * was just synchronized. When it is null there's no new information to load, meaning that the
  * current contents of the notebook are up to date.
+ * @param onMainBranch Boolean indicating whether the sync resulted in a commit on the main branch,
+ * or on a temporary branch.
  * @see GitRepo Which implements [TwoWaySyncRepo]
  * @see TwoWaySyncRepo
  */
-data class TwoWaySyncResult(val newRook: VersionedRook, val loadFile: File?)
+data class TwoWaySyncResult(val newRook: @NotNull VersionedRook, val onMainBranch: Boolean, val loadFile: @Nullable File?)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,8 +197,8 @@
     <string name="git_clone_progress">Cloning repository</string>
     <string name="git_verifying_settings">Ensuring repository settings will work.</string>
     <string name="git_url_hint">Remote URL (e.g. git@github.com:orgzly/orgzly-android.git)</string>
-    <string name="git_directory_hint">Directory location (e.g. “file:/sdcard/orgzly”)</string>
-    <string name="git_ssh_key_hint">SSH key location (e.g. “file:/sdcard/id_rsa”)</string>
+    <string name="git_directory_hint">Directory location (e.g. “/sdcard/orgzly”)</string>
+    <string name="git_ssh_key_hint">SSH key location (e.g. “/sdcard/id_rsa”)</string>
     <string name="git_https_username_hint">Username</string>
     <string name="git_https_password_hint">Password</string>
     <string name="git_author_hint">Author (e.g. John Doe)</string>


### PR DESCRIPTION
Relates to #24.

These changes mean that a sync conflict (merge conflict) no longer prevents any syncing from taking place.

Now, the user can keep syncing to the temporary branch until the merge conflict has been resolved.

Each time syncing takes place, Orgzly will make an attempt to return to the main ranch.

The user can resolve the conflict on the temporary branch, or by merging back to the main branch; it should not matter.

A warning is displayed each time a sync results in Orgzly staying on a temporary branch. This is to remind the user that a merge conflict needs to be resolved outside of Orgzly.