### PR TITLE
Start formatting tables with horizontal scroll and fixed-width font

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
@@ -59,7 +59,7 @@ class ExternalLinksTest(private val param: Parameter) : OrgzlyTest() {
         onBook(0).perform(click())
 
         // Click on link
-        onNoteInBook(1, R.id.item_head_content).perform(clickClickableSpan(param.link))
+        onNoteInBook(1, R.id.item_head_content_list).perform(clickClickableSpan(param.link))
 
         param.check()
     }

--- a/app/src/androidTest/java/com/orgzly/android/espresso/InternalLinksTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/InternalLinksTest.kt
@@ -66,28 +66,28 @@ class InternalLinksTest : OrgzlyTest() {
 
     @Test
     fun testDifferentCaseUuidInternalLink() {
-        onNoteInBook(1, R.id.item_head_content)
+        onNoteInBook(1, R.id.item_head_content_list)
                 .perform(clickClickableSpan("id:bdce923b-C3CD-41ED-B58E-8BDF8BABA54F"))
         onView(withId(R.id.fragment_note_title)).check(matches(withText("Note [b-2]")))
     }
 
     @Test
     fun testDifferentCaseCustomIdInternalLink() {
-        onNoteInBook(2, R.id.item_head_content)
+        onNoteInBook(2, R.id.item_head_content_list)
                 .perform(clickClickableSpan("#Different case custom id"))
         onView(withId(R.id.fragment_note_title)).check(matches(withText("Note [b-1]")))
     }
 
     @Test
     fun testCustomIdLink() {
-        onNoteInBook(3, R.id.item_head_content)
+        onNoteInBook(3, R.id.item_head_content_list)
                 .perform(clickClickableSpan("#Link to note in a different book"))
         onView(withId(R.id.fragment_note_title)).check(matches(withText("Note [b-3]")))
     }
 
     @Test
     fun testBookLink() {
-        onNoteInBook(4, R.id.item_head_content)
+        onNoteInBook(4, R.id.item_head_content_list)
                 .perform(clickClickableSpan("file:book-b.org"))
         onView(withId(R.id.fragment_book_view_flipper)).check(matches(isDisplayed()))
         onNoteInBook(1, R.id.item_head_title).check(matches(withText("Note [b-1]")))
@@ -95,7 +95,7 @@ class InternalLinksTest : OrgzlyTest() {
 
     @Test
     fun testBookRelativeLink() {
-        onNoteInBook(5, R.id.item_head_content)
+        onNoteInBook(5, R.id.item_head_content_list)
                 .perform(clickClickableSpan("file:./book-b.org"))
         onView(withId(R.id.fragment_book_view_flipper)).check(matches(isDisplayed()))
         onNoteInBook(1, R.id.item_head_title).check(matches(withText("Note [b-1]")))

--- a/app/src/androidTest/java/com/orgzly/android/espresso/QueryFragmentTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/QueryFragmentTest.java
@@ -720,7 +720,7 @@ public class QueryFragmentTest extends OrgzlyTest {
         onView(withId(R.id.fragment_query_search_view_flipper)).check(matches(isDisplayed()));
         onNotesInSearch().check(matches(recyclerViewItemCount(3)));
         onNoteInSearch(1, R.id.item_head_title).check(matches(allOf(withText(containsString("Note B")), isDisplayed())));
-        onNoteInSearch(1, R.id.item_head_content).check(matches(allOf(withText(containsString("Content for Note B")), isDisplayed())));
+        onNoteInSearch(1, R.id.item_head_content_list).check(matches(allOf(withText(containsString("Content for Note B")), isDisplayed())));
     }
 
     @Test

--- a/app/src/androidTest/java/com/orgzly/android/espresso/SettingsChangeTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/SettingsChangeTest.java
@@ -82,7 +82,7 @@ public class SettingsChangeTest extends OrgzlyTest {
     public void testDisplayedContentInBook() {
         onBook(0).perform(click());
 
-        onNoteInBook(1, R.id.item_head_content)
+        onNoteInBook(1, R.id.item_head_content_list)
                 .check(matches(allOf(withText(containsString("Content for [a-1]")), isDisplayed())));
 
         onActionItemClick(R.id.activity_action_settings, R.string.settings);
@@ -91,7 +91,7 @@ public class SettingsChangeTest extends OrgzlyTest {
         pressBack();
         pressBack();
 
-        onNoteInBook(1, R.id.item_head_content).check(matches(not(isDisplayed())));
+        onNoteInBook(1, R.id.item_head_content_list).check(matches(not(isDisplayed())));
     }
 
     private void setDefaultPriority(String priority) {

--- a/app/src/androidTest/java/com/orgzly/android/ui/notes/NoteContentTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/ui/notes/NoteContentTest.kt
@@ -1,0 +1,154 @@
+package com.orgzly.android.ui.notes
+
+import com.orgzly.android.ui.notes.NoteContent.TableNoteContent
+import com.orgzly.android.ui.notes.NoteContent.TextNoteContent
+import org.hamcrest.Matchers.emptyCollectionOf
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThat
+import org.junit.Test
+import java.util.Random
+
+// TODO - check CRLF vs LF vs whatever MacOS does
+class NoteContentTest {
+
+    @Test
+    fun emptyString() {
+        val parse = NoteContent.parse("")
+        assertThat(parse, (emptyCollectionOf(NoteContent.javaClass)))
+    }
+
+    @Test
+    fun emptyLinesShouldStayInSingleSection() {
+        checkExpected("\n\n", listOf(TextNoteContent("\n\n")))
+    }
+
+    @Test
+    fun pipeInText() {
+        checkExpected("""foo
+|
+
+foo|bar""", listOf(
+                TextNoteContent("foo\n"),
+                TableNoteContent("|\n"),
+                TextNoteContent("\nfoo|bar")
+        ))
+    }
+
+    @Test
+    fun singleTable() {
+        checkExpected("""|a|b|
+|c|d|
+""", listOf(TableNoteContent("""|a|b|
+|c|d|
+""")))
+    }
+
+    @Test
+    fun singleTableNoFinalNewline() {
+        checkExpected("""|a|b|
+|c|d|""", listOf(TableNoteContent("""|a|b|
+|c|d|""")))
+    }
+
+    @Test
+    fun singleLineTextTableText() {
+        checkExpected("""foo
+|
+bar""", listOf(
+                TextNoteContent("foo\n"),
+                TableNoteContent("|\n"),
+                TextNoteContent("bar")
+        ))
+    }
+
+
+    @Test
+    fun blankLineTextTableText() {
+        checkExpected("""
+|
+bar
+""", listOf(
+                TextNoteContent("\n"),
+                TableNoteContent("|\n"),
+                TextNoteContent("bar\n")
+        ))
+    }
+
+    @Test
+    fun tableBlankLineTable() {
+        checkExpected("""|zoo|
+
+|zog|""", listOf(
+                TableNoteContent("|zoo|\n"),
+                TextNoteContent("\n"),
+                TableNoteContent("|zog|")
+        ))
+    }
+
+    @Test
+    fun textTableBlankLineText() {
+        checkExpected("""foo
+|
+
+chops""", listOf(
+                TextNoteContent("foo\n"),
+                TableNoteContent("|\n"),
+                TextNoteContent("\nchops")
+        ))
+    }
+
+
+    @Test
+    fun textTableTextTableText() {
+        checkExpected("""text1
+|table2a|
+|table2b|
+text3a
+text3b
+text3c
+|table4|
+text5
+""", listOf(
+                TextNoteContent("text1\n"),
+                TableNoteContent("|table2a|\n|table2b|\n"),
+                TextNoteContent("text3a\ntext3b\ntext3c\n"),
+                TableNoteContent("|table4|\n"),
+                TextNoteContent("text5\n")
+        ))
+    }
+
+    @Test
+    fun randomStringsRoundTrip() {
+
+        val stringAtoms: List<String> = listOf("\n", "a", "|")
+
+        for (i in 0..1000) {
+            val rawStringLength = Random().nextInt(100)
+            val builder = StringBuilder()
+            for (j in 0..rawStringLength) {
+                builder.append(stringAtoms.random())
+            }
+
+            val raw = builder.toString()
+
+            val actual: List<NoteContent> = NoteContent.parse(raw)
+
+            val roundTripped: String = actual.fold("") { acc: String, current: NoteContent -> acc + current.text }
+
+            assertEquals(raw, roundTripped)
+
+        }
+
+    }
+
+
+    private fun checkExpected(input: String, expected: List<NoteContent>) {
+        val actual: List<NoteContent> = NoteContent.parse(input)
+        assertEquals(expected, actual)
+
+        val roundTripped: String = actual.fold("") { acc: String, current: NoteContent -> acc + current.text }
+
+        assertEquals(input, roundTripped)
+
+    }
+}

--- a/app/src/main/java/com/orgzly/android/ui/notes/NoteContent.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NoteContent.kt
@@ -1,0 +1,88 @@
+package com.orgzly.android.ui.notes
+
+/**
+ * Represents a subsection of note content: either text, or a table
+ */
+sealed class NoteContent {
+
+    abstract val text: String
+
+    data class TextNoteContent(override val text: String) : NoteContent() {
+    }
+
+    data class TableNoteContent(override val text: String) : NoteContent() {
+
+        fun reformat() {
+            // placeholder - but would fix all the spacing, missing cells, etc. Complicated
+        }
+    }
+
+
+    companion object {
+
+        private fun lineIsTable(raw: String) = raw.length > 0 && raw.get(0) == '|'
+
+        /**
+         * Converts the provided raw string  (with embedded newlines) into a list of sections of
+         * either text or tables. Each section is contiguous and can contain newlines.
+         *
+         * This is horrible, never try to write your own parser. Consider using a regex instead.
+         */
+        fun parse(raw: String): List<NoteContent> {
+            val list: MutableList<NoteContent> = mutableListOf()
+
+            var currentText = ""
+            var currentTable = ""
+
+            var previousIsTable: Boolean = this.lineIsTable(raw)
+
+            val rawSplitByNewlines = raw.split("\n")
+
+            val missingLastNewline = rawSplitByNewlines.last() != ""
+
+            val linesForParsing =
+                    if (missingLastNewline) {
+                        rawSplitByNewlines
+                    } else {
+                        rawSplitByNewlines.dropLast(1)
+                    }
+
+            linesForParsing.forEach {
+                val currentIsTable = lineIsTable(it)
+                when {
+                    currentIsTable && previousIsTable -> {
+                        currentTable += it + "\n"
+                    }
+                    currentIsTable && !previousIsTable -> {
+                        currentTable = it + "\n"
+                        list.add(TextNoteContent(currentText))
+                        currentText = ""
+                    }
+                    !currentIsTable && previousIsTable -> {
+                        currentText = it + "\n"
+                        list.add(TableNoteContent(currentTable))
+                        currentTable = ""
+                    }
+                    !currentIsTable && !previousIsTable -> {
+                        currentText += it + "\n"
+                    }
+                }
+                previousIsTable = currentIsTable
+            }
+
+            if (linesForParsing.isNotEmpty()) {
+                if (previousIsTable) {
+                    list.add(TableNoteContent(if (missingLastNewline) {
+                        currentTable.dropLast(1)
+                    } else currentTable))
+                } else {
+                    list.add(TextNoteContent(if (missingLastNewline) {
+                        currentText.dropLast(1)
+                    } else currentText))
+                }
+            }
+
+            return list
+        }
+    }
+}

--- a/app/src/main/java/com/orgzly/android/ui/notes/NoteItemViewBinder.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NoteItemViewBinder.kt
@@ -1,10 +1,11 @@
 package com.orgzly.android.ui.notes
 
 import android.content.Context
-import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -13,10 +14,10 @@ import com.orgzly.android.App
 import com.orgzly.android.db.entity.Note
 import com.orgzly.android.db.entity.NoteView
 import com.orgzly.android.prefs.AppPreferences
-import com.orgzly.android.ui.ImageLoader
 import com.orgzly.android.ui.TimeType
 import com.orgzly.android.ui.util.TitleGenerator
 import com.orgzly.android.ui.util.styledAttributes
+import com.orgzly.android.ui.views.TextViewWithMarkup
 import com.orgzly.android.usecase.NoteToggleFolding
 import com.orgzly.android.usecase.NoteToggleFoldingSubtree
 import com.orgzly.android.usecase.NoteUpdateContent
@@ -109,35 +110,63 @@ class NoteItemViewBinder(private val context: Context, private val inBook: Boole
     }
 
     private fun setupContent(holder: NoteItemViewHolder, note: Note) {
-        holder.binding.itemHeadContent.text = note.content
 
         if (note.hasContent() && titleGenerator.shouldDisplayContent(note)) {
-            if (AppPreferences.isFontMonospaced(context)) {
-                holder.binding.itemHeadContent.typeface = Typeface.MONOSPACE
-            }
 
-            holder.binding.itemHeadContent.setRawText(note.content as CharSequence)
+            // this is absolutely not the place to split the note, but doing it here for PoC
+            val alternatingTableAndTextContent: List<NoteContent> = NoteContent.parse(note.content!!)
 
-            /* If content changes (for example by toggling the checkbox), update the note. */
-            holder.binding.itemHeadContent.onUserTextChangeListener = Runnable {
-                if (holder.binding.itemHeadContent.getRawText() != null) {
-                    val useCase = NoteUpdateContent(
-                            note.position.bookId,
-                            note.id,
-                            holder.binding.itemHeadContent.getRawText()?.toString())
+            val linearLayout = holder.itemView.findViewById<LinearLayout>(R.id.item_head_content_list)
 
-                    App.EXECUTORS.diskIO().execute {
-                        UseCaseRunner.run(useCase)
+            linearLayout.removeAllViews()
+
+            val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+
+            alternatingTableAndTextContent.forEach { aocNoteContent ->
+                when (aocNoteContent) {
+                    is NoteContent.TableNoteContent -> {
+
+                        val aocSectionTableTextView = layoutInflater.inflate(R.layout.item_note_content_section_table, linearLayout, false)
+
+                        aocSectionTableTextView.findViewById<TextView>(R.id.aoc_section_table_text).text = aocNoteContent.text
+
+                        linearLayout.addView(aocSectionTableTextView)
+                    }
+                    else -> {
+
+                        val layout = layoutInflater.inflate(R.layout.item_note_content_section_text, linearLayout, false)
+
+                        val textView = layout.findViewById<TextViewWithMarkup>(R.id.aoc_section_text)
+
+                        textView.setRawText(aocNoteContent.text)
+
+                        linearLayout.addView(layout)
+
+                        /* If content changes (for example by toggling the checkbox), update the note. */
+                        textView.onUserTextChangeListener = Runnable {
+                            if (textView.getRawText() != null) {
+                                val useCase = NoteUpdateContent(
+                                        note.position.bookId,
+                                        note.id,
+                                        textView.getRawText()?.toString())
+
+                                App.EXECUTORS.diskIO().execute {
+                                    UseCaseRunner.run(useCase)
+                                }
+                            }
+                        }
+
+                        // TODO restore this
+//                        ImageLoader.loadImages(holder.binding.itemHeadContent)
                     }
                 }
+
             }
 
-            ImageLoader.loadImages(holder.binding.itemHeadContent)
-
-            holder.binding.itemHeadContent.visibility = View.VISIBLE
+            holder.binding.itemHeadContentList.visibility = View.VISIBLE
 
         } else {
-            holder.binding.itemHeadContent.visibility = View.GONE
+            holder.binding.itemHeadContentList.visibility = View.GONE
         }
     }
 
@@ -425,7 +454,7 @@ class NoteItemViewBinder(private val context: Context, private val inBook: Boole
                     binding.itemHeadEventIcon,
                     binding.itemHeadClosedIcon,
                     binding.itemHeadClosedText,
-                    binding.itemHeadContent)
+                    binding.itemHeadContentList)
 
             for (view in views) {
                 (view.layoutParams as ConstraintLayout.LayoutParams).apply {

--- a/app/src/main/res/layout/item_head.xml
+++ b/app/src/main/res/layout/item_head.xml
@@ -26,7 +26,7 @@
 
         <View
             android:id="@+id/item_head_bottom"
-            app:layout_constraintTop_toBottomOf="@id/item_head_content"
+            app:layout_constraintTop_toBottomOf="@id/item_head_content_list"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_width="match_parent"
             android:layout_height="100dp"
@@ -239,18 +239,17 @@
             tools:text="@string/note_closed_sample" />
 
         <!-- Content -->
-        <com.orgzly.android.ui.views.TextViewWithMarkup
-            android:id="@+id/item_head_content"
+        <LinearLayout
+            android:id="@+id/item_head_content_list"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:textColor="?attr/item_head_post_title_color"
-            android:textSize="?attr/item_head_sub_title_content_text"
-            android:alpha="@{alpha}"
             app:layout_constraintTop_toBottomOf="@+id/item_head_closed_text"
             app:layout_constraintStart_toStartOf="@+id/item_head_title"
             app:layout_constraintEnd_toStartOf="@+id/item_head_fold_button_text"
-            tools:text="@string/note_content_sample"
+            android:orientation="vertical"
             android:visibility="visible" />
+
+        <!-- TODO restore android:alpha="@{alpha}" in the above -->
 
         <!-- Folding button -->
         <View
@@ -272,7 +271,7 @@
             android:textColor="?attr/item_head_post_title_color"
             android:textSize="?attr/item_head_fold_button_text_size"
             app:layout_constraintTop_toTopOf="@+id/item_head_title"
-            app:layout_constraintBottom_toBottomOf="@+id/item_head_content"
+            app:layout_constraintBottom_toBottomOf="@+id/item_head_content_list"
             app:layout_constraintEnd_toEndOf="parent" />
 
         <include
@@ -280,7 +279,7 @@
             layout="@layout/quick_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@+id/item_head_content"
+            app:layout_constraintTop_toBottomOf="@+id/item_head_content_list"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/item_note_content_section_table.xml
+++ b/app/src/main/res/layout/item_note_content_section_table.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <HorizontalScrollView
+        android:id="@+id/aoc_section_table_scrollview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/aoc_section_table_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:typeface="monospace"
+            tools:text="| a bit of | table |" />
+    </HorizontalScrollView>
+</layout>

--- a/app/src/main/res/layout/item_note_content_section_text.xml
+++ b/app/src/main/res/layout/item_note_content_section_text.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <com.orgzly.android.ui.views.TextViewWithMarkup
+        android:id="@+id/aoc_section_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/item_head_post_title_color"
+        android:textSize="?attr/item_head_sub_title_content_text"
+        tools:text="plain text rather than a table" />
+
+    <!-- TODO restore this
+        android:alpha="@{alpha}"
+    -->
+</layout>

--- a/app/src/main/res/raw/orgzly_getting_started.org
+++ b/app/src/main/res/raw/orgzly_getting_started.org
@@ -70,6 +70,20 @@ You can make words *bold*, /italic/, _underlined_, =verbatim=, ~code~ and +strik
 
 Click the checkbox to toggle it. Press new-line button at the end of the line to create a new item.
 
+** Tables can be created
+
+A table starts the line with the pipe | character.
+
+| Here is a table                 |                   |                |       |
+| We rely on horizontal scrolling | to show very wide |  table content |       |
+
+You can have more than one table in a note.
+
+| Like this | one     |
+| for       | example |
+
+Editing tables is not yet supported.
+
 * Search
 ** There are many search operators supported
 


### PR DESCRIPTION
Followup from discussion on https://github.com/orgzly/orgzly-android/issues/74

In this approach the note's content is split into alternating table and text (i.e. non-table) content. The tables are then formatted with a fixed-width font, and horizontal scrolling is used to prevent text wrapping (wrapping makes tables basically unusable)

Before merging I'd at least need to address:

* test breakage
* adding more tests
* consider what to do about editing tables
* consider pushing down the parsing of table content into `org-java` library and storing result of the table/text parsing process in the database