### PR TITLE
Add light/dark theme that follows system setting

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/CommonActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/CommonActivity.kt
@@ -274,6 +274,9 @@ abstract class CommonActivity : AppCompatActivity() {
     private fun setupTheme() {
         // Set theme (color scheme)
         when (AppPreferences.colorScheme(this)) {
+            getString(R.string.pref_value_color_scheme_system) ->
+                setTheme(R.style.AppDayNightTheme)
+
             getString(R.string.pref_value_color_scheme_dark) ->
                 setTheme(R.style.AppDarkTheme_Dark)
 

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppDayNightTheme" parent="AppDarkTheme" />
+</resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -350,6 +350,7 @@
     <string name="displayed_book_details_used_encoding">Используемая кодировка</string>
     <string name="displayed_book_details_last_action">Последнее действие</string>
     <string name="displayed_book_details_notes_count">Количество заметок</string>
+    <string name="color_scheme_system">Использовать системную настройку</string>
     <string name="color_scheme_light">Светлая</string>
     <string name="color_scheme_dark">Темная</string>
     <string name="color_scheme_black">Черная</string>

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -102,16 +102,19 @@
 
     <!-- Color scheme. -->
     <string name="pref_key_color_scheme" translatable="false">pref_key_color_scheme</string>
-    <string name="pref_default_color_scheme" translatable="false">@string/pref_value_color_scheme_light</string>
+    <string name="pref_default_color_scheme" translatable="false">@string/pref_value_color_scheme_system</string>
+    <string name="pref_value_color_scheme_system" translatable="false">system</string>
     <string name="pref_value_color_scheme_light" translatable="false">light</string>
     <string name="pref_value_color_scheme_dark" translatable="false">dark</string>
     <string name="pref_value_color_scheme_black" translatable="false">black</string>
     <string-array name="color_scheme">
+        <item>@string/color_scheme_system</item>
         <item>@string/color_scheme_light</item>
         <item>@string/color_scheme_dark</item>
         <item>@string/color_scheme_black</item>
     </string-array>
     <string-array name="color_scheme_values">
+        <item>@string/pref_value_color_scheme_system</item>
         <item>@string/pref_value_color_scheme_light</item>
         <item>@string/pref_value_color_scheme_dark</item>
         <item>@string/pref_value_color_scheme_black</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -402,6 +402,7 @@
     <string name="displayed_book_details_last_action">Last action</string>
     <string name="displayed_book_details_notes_count" >Notes count</string>
 
+    <string name="color_scheme_system">Use system setting</string>
     <string name="color_scheme_light">Light</string>
     <string name="color_scheme_dark">Dark</string>
     <string name="color_scheme_black">Black</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,6 +3,8 @@
 <resources
     xmlns:tools="http://schemas.android.com/tools">
 
+    <style name="AppDayNightTheme" parent="AppLightTheme" />
+
     <!--
          Custom light themes should inherit from AppLightTheme, dark themes from AppDarkTheme.
          They both contain same default font and icon sizes. TODO: DRY (how?)


### PR DESCRIPTION
Resolves #797

I took the lazy approach and created new theme that references existing `AppLightTheme` and `AppDarkTheme` themes for day and night modes repectively.

Better solution wold be to implement new theme based on `Theme.AppCompat.DayNight.NoActionBar` and remove `AppLightTheme` & `AppDarkTheme`. I can do that but decided to ask if it is ok with project roadmap first.

Also, I managet to add string resources for English and Russian only.