### PR TITLE
Git: Always create temp branches from the pre-sync HEAD commit.

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/TestUtils.java
+++ b/app/src/androidTest/java/com/orgzly/android/TestUtils.java
@@ -136,7 +136,7 @@ public class TestUtils {
             Map<String, BookNamesake> nameGroups = SyncService.groupAllNotebooksByName(dataRepository);
 
             for (BookNamesake group : nameGroups.values()) {
-                BookAction action = SyncService.syncNamesake(dataRepository, group);
+                BookAction action = SyncService.syncNamesake(dataRepository, group, null);
                 dataRepository.setBookLastActionAndSyncStatus(
                         group.getBook().getBook().getId(), action, group.getStatus().toString());
             }

--- a/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
+++ b/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
@@ -128,7 +128,7 @@ public class GitFileSynchronizer {
 
     public boolean updateAndCommitFileFromRevisionAndMerge(
             File sourceFile, String repositoryPath,
-            ObjectId fileRevision, RevCommit revision)
+            ObjectId fileRevision, RevCommit revision, RevCommit branchStartPoint)
             throws IOException {
         ensureRepoIsClean();
         if (updateAndCommitFileFromRevision(sourceFile, repositoryPath, fileRevision)) {
@@ -145,8 +145,8 @@ public class GitFileSynchronizer {
         try {
             RevCommit mergeTarget = currentHead();
             git.checkout().setCreateBranch(true).setForce(true).
-                    setStartPoint(revision).setName(mergeBranch).call();
-            if (!currentHead().equals(revision))
+                    setStartPoint(branchStartPoint).setName(mergeBranch).call();
+            if (!currentHead().equals(branchStartPoint))
                 throw new IOException("Unable to set revision to " + revision.toString());
             if (!updateAndCommitFileFromRevision(sourceFile, repositoryPath, fileRevision))
                 throw new IOException(

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -322,7 +322,7 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
 
     @Override
     public TwoWaySyncResult syncBook(
-            Uri uri, VersionedRook current, File fromDB) throws IOException {
+            Uri uri, VersionedRook current, File fromDB, RevCommit branchStartPoint) throws IOException {
         File writeBack = null;
         boolean onMainBranch = true;
         String fileName = uri.getPath();
@@ -335,7 +335,7 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
             boolean merged = synchronizer.updateAndCommitFileFromRevisionAndMerge(
                     fromDB, fileName,
                     synchronizer.getFileRevision(fileName, rookCommit),
-                    rookCommit);
+                    rookCommit, branchStartPoint);
 
             // We have attempted a merge. Are we back on the main branch, or still on a temp branch?
             onMainBranch = git.getRepository().getBranch().equals(preferences.branchName());
@@ -362,5 +362,15 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
 
     public void tryPushIfHeadDiffersFromRemote() {
         synchronizer.tryPushIfHeadDiffersFromRemote();
+    }
+    
+    public RevCommit getCurrentHead() {
+        RevCommit current = null;
+        try {
+            current = synchronizer.currentHead();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return current;
     }
 }

--- a/app/src/main/java/com/orgzly/android/repos/TwoWaySyncRepo.kt
+++ b/app/src/main/java/com/orgzly/android/repos/TwoWaySyncRepo.kt
@@ -1,12 +1,15 @@
 package com.orgzly.android.repos
 
 import android.net.Uri
+import org.eclipse.jgit.revwalk.RevCommit
 import java.io.File
 import java.io.IOException
 
 interface TwoWaySyncRepo {
     @Throws(IOException::class)
-    fun syncBook(uri: Uri, current: VersionedRook?, fromDB: File): TwoWaySyncResult
+    fun syncBook(uri: Uri, current: VersionedRook?, fromDB: File, branchStartPoint: RevCommit?): TwoWaySyncResult
 
     fun tryPushIfHeadDiffersFromRemote()
+    
+    fun getCurrentHead(): RevCommit
 }


### PR DESCRIPTION
I know that these additions to SyncService aren't pretty, but this solves the only remaining problem with how Git syncing behaves.

If someone can come up with a better way to achieve this, I'm all ears.

This solves #790. That issue description does not explain the underlying problem, but I believe the commit message does.

All the tests in SyncingTests are green, and I've tested this with a local directory repo without any issues. 

I have not tested this with Dropbox or WebDAV repos, but I'll gladly do that if I know this PR is considered for merging.