### PR TITLE
Introduce custom timeout for server connection (#870)

### DIFF
--- a/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
+++ b/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
@@ -107,6 +107,7 @@ class WebdavRepo(
         const val PASSWORD_PREF_KEY = "password"
         const val CERTIFICATES_PREF_KEY = "certificates"
         const val CONNECTION_TIMEOUT_PREF_KEY = "connectionTimeout"
+		const val USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY = "useCustomTimeout"
 
         fun getInstance(repoWithProps: RepoWithProps): WebdavRepo {
             val id = repoWithProps.repo.id
@@ -123,7 +124,9 @@ class WebdavRepo(
 
             val certificates = repoWithProps.props[CERTIFICATES_PREF_KEY]
 
-            val connectionTimeout = repoWithProps.props[CONNECTION_TIMEOUT_PREF_KEY]?.toUIntOrNull()
+			val useCustomConnectionTimeout = repoWithProps.props[USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY].toBoolean()
+
+            val connectionTimeout = if (useCustomConnectionTimeout) repoWithProps.props[CONNECTION_TIMEOUT_PREF_KEY]?.toUIntOrNull() else null
 
             return WebdavRepo(id, uri, username, password, certificates, connectionTimeout)
         }

--- a/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
+++ b/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
@@ -5,6 +5,8 @@ import com.orgzly.android.BookName
 import com.orgzly.android.util.UriUtils
 import com.thegrizzlylabs.sardineandroid.DavResource
 import com.thegrizzlylabs.sardineandroid.impl.OkHttpSardine
+import okhttp3.OkHttpClient
+import okio.Buffer
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
@@ -15,8 +17,6 @@ import java.util.concurrent.TimeUnit
 import javax.net.ssl.*
 import kotlin.text.toUInt
 import kotlin.text.toUIntOrNull
-import okhttp3.OkHttpClient
-import okio.Buffer
 
 class WebdavRepo(
         private val repoId: Long,
@@ -24,21 +24,21 @@ class WebdavRepo(
         username: String,
         password: String,
         certificates: String? = null,
-        connectionTimeout: UInt? = null
+        customTimeout: UInt? = null
 ) : SyncRepo {
 
     private val sardine =
-            client(certificates, connectionTimeout).apply { setCredentials(username, password) }
+            client(certificates, customTimeout).apply { setCredentials(username, password) }
 
-    private fun client(certificates: String?, connectionTimeout: UInt?): OkHttpSardine {
+    private fun client(certificates: String?, customTimeout: UInt?): OkHttpSardine {
         var okClient: OkHttpClient
         okClient = if (certificates.isNullOrEmpty()) {
             OkHttpClient.Builder().build()
         } else {
             okHttpClientWithTrustedCertificates(certificates)
         }
-        if (connectionTimeout != null) {
-            okClient = setTimeouts(okClient, connectionTimeout)
+        if (customTimeout != null) {
+            okClient = setTimeouts(okClient, customTimeout)
         }
         return OkHttpSardine(okClient)
     }
@@ -106,8 +106,8 @@ class WebdavRepo(
         const val USERNAME_PREF_KEY = "username"
         const val PASSWORD_PREF_KEY = "password"
         const val CERTIFICATES_PREF_KEY = "certificates"
-        const val CONNECTION_TIMEOUT_PREF_KEY = "connectionTimeout"
-		const val USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY = "useCustomTimeout"
+        const val CUSTOM_TIMEOUT_PREF_KEY = "customTimeout"
+		const val USE_CUSTOM_TIMEOUT_PREF_KEY = "useCustomTimeout"
 
         fun getInstance(repoWithProps: RepoWithProps): WebdavRepo {
             val id = repoWithProps.repo.id
@@ -124,11 +124,11 @@ class WebdavRepo(
 
             val certificates = repoWithProps.props[CERTIFICATES_PREF_KEY]
 
-			val useCustomConnectionTimeout = repoWithProps.props[USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY].toBoolean()
+			val useCustomConnectionTimeout = repoWithProps.props[USE_CUSTOM_TIMEOUT_PREF_KEY].toBoolean()
 
-            val connectionTimeout = if (useCustomConnectionTimeout) repoWithProps.props[CONNECTION_TIMEOUT_PREF_KEY]?.toUIntOrNull() else null
+            val customTimeout = if (useCustomConnectionTimeout) repoWithProps.props[CUSTOM_TIMEOUT_PREF_KEY]?.toUIntOrNull() else null
 
-            return WebdavRepo(id, uri, username, password, certificates, connectionTimeout)
+            return WebdavRepo(id, uri, username, password, certificates, customTimeout)
         }
     }
 

--- a/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
+++ b/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
@@ -13,6 +13,7 @@ import java.io.InputStream
 import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import java.util.*
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.*
 
 
@@ -29,12 +30,18 @@ class WebdavRepo(
     }
 
     private fun client(certificates: String?): OkHttpSardine {
-        return if (certificates.isNullOrEmpty()) {
-            OkHttpSardine()
+		var okClient: OkHttpClient; 
+        if (certificates.isNullOrEmpty()) {
+			okClient = OkHttpClient.Builder().build(); 
         } else {
-            OkHttpSardine(okHttpClientWithTrustedCertificates(certificates))
+            okClient = okHttpClientWithTrustedCertificates(certificates);
         }
+		return OkHttpSardine(setTimeouts(okClient));
     }
+
+	private fun setTimeouts(okClient: OkHttpClient): OkHttpClient {
+		return okClient.newBuilder().connectTimeout(200, TimeUnit.SECONDS).readTimeout(200, TimeUnit.SECONDS).writeTimeout(200,TimeUnit.SECONDS).build();
+	}
 
     private fun okHttpClientWithTrustedCertificates(certificates: String): OkHttpClient {
         val trustManager = trustManagerForCertificates(certificates)

--- a/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoActivity.kt
@@ -231,10 +231,12 @@ class WebdavRepoActivity : CommonActivity() {
 	private fun getCustomConnectionTimeout(): String? {
 		return if (getCustomConnectionTimeoutEnabled()) getCustomConnectionTimeoutValue() else null
 	}
+ 	   private fun isInputValid(): Boolean {
         val url = getUrl()
         val username = getUsername()
         val password = getPassword()
-		val timeout = getConnectionTimeout()
+		val timeout = getCustomConnectionTimeoutValue()
+		val useCustomTimeout = getCustomConnectionTimeoutEnabled()
 
         binding.activityRepoWebdavUrlLayout.error = when {
             TextUtils.isEmpty(url) -> getString(R.string.can_not_be_empty)
@@ -254,7 +256,9 @@ class WebdavRepoActivity : CommonActivity() {
         }
 
 		binding.activityRepoWebdavCustomTimeoutValueLayout.error = when {
-			(timeout != null && timeout.toUIntOrNull() == null) -> getString(R.string.invalid_number)
+			!useCustomTimeout -> null
+			TextUtils.isEmpty(timeout) -> getString(R.string.can_not_be_empty)
+			(timeout.toUIntOrNull() == null || timeout.toUInt() > OKHTTP_MAX_TIMEOUT) -> getString(R.string.number_too_large_or_invalid)
 			else -> null
 		}
 
@@ -307,6 +311,7 @@ class WebdavRepoActivity : CommonActivity() {
         private const val ARG_REPO_ID = "repo_id"
 
         private val WEB_DAV_SCHEME_REGEX = Regex("^(webdav|dav|http)s?://.+\$")
+		private val OKHTTP_MAX_TIMEOUT = 2147483u
 
         @JvmStatic
         @JvmOverloads

--- a/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoActivity.kt
@@ -21,6 +21,7 @@ import com.orgzly.android.repos.WebdavRepo.Companion.CERTIFICATES_PREF_KEY
 import com.orgzly.android.repos.WebdavRepo.Companion.PASSWORD_PREF_KEY
 import com.orgzly.android.repos.WebdavRepo.Companion.USERNAME_PREF_KEY
 import com.orgzly.android.repos.WebdavRepo.Companion.CONNECTION_TIMEOUT_PREF_KEY
+import com.orgzly.android.repos.WebdavRepo.Companion.USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY
 import com.orgzly.android.ui.CommonActivity
 import com.orgzly.android.ui.util.ActivityUtils
 import com.orgzly.android.util.UriUtils
@@ -123,8 +124,10 @@ class WebdavRepoActivity : CommonActivity() {
                 binding.activityRepoWebdavUsername.setText(repoWithProps.props[USERNAME_PREF_KEY])
                 binding.activityRepoWebdavPassword.setText(repoWithProps.props[PASSWORD_PREF_KEY])
 				if(repoWithProps.props[CONNECTION_TIMEOUT_PREF_KEY] != null){
-				binding.activityRepoWebdavCustomTimeoutValue.setText(repoWithProps.props[CONNECTION_TIMEOUT_PREF_KEY])
-				binding.activityRepoWebdavCustomTimeoutEnabled.setChecked(true)
+					binding.activityRepoWebdavCustomTimeoutValue.setText(repoWithProps.props[CONNECTION_TIMEOUT_PREF_KEY])
+				}
+				if (repoWithProps.props[USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY].toBoolean()){
+                    binding.activityRepoWebdavCustomTimeoutEnabled.setChecked(true)
 				}
                 else {
                     binding.activityRepoWebdavCustomTimeoutEnabled.setChecked(false)
@@ -165,7 +168,8 @@ class WebdavRepoActivity : CommonActivity() {
             val username = getUsername()
             val password = getPassword()
             val certificates = getCertificates()
-			val connectionTimeout = getConnectionTimeout()
+			val connectionTimeoutValue = getCustomConnectionTimeoutValue()
+			val useCustomConnectionTimeout = getCustomConnectionTimeoutEnabled()
 
             val props = mutableMapOf(
                     USERNAME_PREF_KEY to username,
@@ -175,8 +179,12 @@ class WebdavRepoActivity : CommonActivity() {
                 props[CERTIFICATES_PREF_KEY] = certificates
             }
 
-			if (connectionTimeout != null) {
-                props[CONNECTION_TIMEOUT_PREF_KEY] = connectionTimeout
+			if (connectionTimeoutValue != null) {
+                props[CONNECTION_TIMEOUT_PREF_KEY] = connectionTimeoutValue
+			}
+
+			if (useCustomConnectionTimeout) {
+				props[USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY] = useCustomConnectionTimeout.toString()
 			}
 
             if (UriUtils.isUrlSecure(uriString)) {
@@ -212,15 +220,17 @@ class WebdavRepoActivity : CommonActivity() {
         return viewModel.certificates.value
     }
 
-	private fun getConnectionTimeout(): String? {
-		return if (binding.activityRepoWebdavCustomTimeoutEnabled.isChecked) {
-		binding.activityRepoWebdavCustomTimeoutValue.text.toString().trim { it <= ' '}
-		}
-		else
-		null
+	private fun getCustomConnectionTimeoutEnabled(): Boolean {
+		return binding.activityRepoWebdavCustomTimeoutEnabled.isChecked
 	}
 
-    private fun isInputValid(): Boolean {
+    private fun getCustomConnectionTimeoutValue(): String {
+     	return binding.activityRepoWebdavCustomTimeoutValue.text.toString().trim { it <= ' ' }
+    }
+
+	private fun getCustomConnectionTimeout(): String? {
+		return if (getCustomConnectionTimeoutEnabled()) getCustomConnectionTimeoutValue() else null
+	}
         val url = getUrl()
         val username = getUsername()
         val password = getPassword()
@@ -288,7 +298,7 @@ class WebdavRepoActivity : CommonActivity() {
         val username = getUsername()
         val password = getPassword()
         val certificates = getCertificates()
-        val connectionTimeout = getConnectionTimeout()?.toUIntOrNull()
+        val connectionTimeout = getCustomConnectionTimeout()?.toUIntOrNull()
 
         viewModel.testConnection(uriString, username, password, certificates, connectionTimeout)
     }

--- a/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoActivity.kt
@@ -20,8 +20,8 @@ import com.orgzly.android.repos.RepoType
 import com.orgzly.android.repos.WebdavRepo.Companion.CERTIFICATES_PREF_KEY
 import com.orgzly.android.repos.WebdavRepo.Companion.PASSWORD_PREF_KEY
 import com.orgzly.android.repos.WebdavRepo.Companion.USERNAME_PREF_KEY
-import com.orgzly.android.repos.WebdavRepo.Companion.CONNECTION_TIMEOUT_PREF_KEY
-import com.orgzly.android.repos.WebdavRepo.Companion.USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY
+import com.orgzly.android.repos.WebdavRepo.Companion.CUSTOM_TIMEOUT_PREF_KEY
+import com.orgzly.android.repos.WebdavRepo.Companion.USE_CUSTOM_TIMEOUT_PREF_KEY
 import com.orgzly.android.ui.CommonActivity
 import com.orgzly.android.ui.util.ActivityUtils
 import com.orgzly.android.util.UriUtils
@@ -123,10 +123,10 @@ class WebdavRepoActivity : CommonActivity() {
 
                 binding.activityRepoWebdavUsername.setText(repoWithProps.props[USERNAME_PREF_KEY])
                 binding.activityRepoWebdavPassword.setText(repoWithProps.props[PASSWORD_PREF_KEY])
-				if(repoWithProps.props[CONNECTION_TIMEOUT_PREF_KEY] != null){
-					binding.activityRepoWebdavCustomTimeoutValue.setText(repoWithProps.props[CONNECTION_TIMEOUT_PREF_KEY])
+				if(repoWithProps.props[CUSTOM_TIMEOUT_PREF_KEY] != null){
+					binding.activityRepoWebdavCustomTimeoutValue.setText(repoWithProps.props[CUSTOM_TIMEOUT_PREF_KEY])
 				}
-				if (repoWithProps.props[USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY].toBoolean()){
+				if (repoWithProps.props[USE_CUSTOM_TIMEOUT_PREF_KEY].toBoolean()){
                     binding.activityRepoWebdavCustomTimeoutEnabled.setChecked(true)
 				}
                 else {
@@ -168,8 +168,8 @@ class WebdavRepoActivity : CommonActivity() {
             val username = getUsername()
             val password = getPassword()
             val certificates = getCertificates()
-			val connectionTimeoutValue = getCustomConnectionTimeoutValue()
-			val useCustomConnectionTimeout = getCustomConnectionTimeoutEnabled()
+			val timeoutValue = getCustomTimeoutValue()
+			val useCustomTimeout = getCustomTimeoutEnabled()
 
             val props = mutableMapOf(
                     USERNAME_PREF_KEY to username,
@@ -179,12 +179,12 @@ class WebdavRepoActivity : CommonActivity() {
                 props[CERTIFICATES_PREF_KEY] = certificates
             }
 
-			if (connectionTimeoutValue != null) {
-                props[CONNECTION_TIMEOUT_PREF_KEY] = connectionTimeoutValue
+			if (timeoutValue != null) {
+                props[CUSTOM_TIMEOUT_PREF_KEY] = timeoutValue
 			}
 
-			if (useCustomConnectionTimeout) {
-				props[USE_CUSTOM_CONNECTION_TIMEOUT_PREF_KEY] = useCustomConnectionTimeout.toString()
+			if (useCustomTimeout) {
+				props[USE_CUSTOM_TIMEOUT_PREF_KEY] = useCustomTimeout.toString()
 			}
 
             if (UriUtils.isUrlSecure(uriString)) {
@@ -220,23 +220,23 @@ class WebdavRepoActivity : CommonActivity() {
         return viewModel.certificates.value
     }
 
-	private fun getCustomConnectionTimeoutEnabled(): Boolean {
+	private fun getCustomTimeoutEnabled(): Boolean {
 		return binding.activityRepoWebdavCustomTimeoutEnabled.isChecked
 	}
 
-    private fun getCustomConnectionTimeoutValue(): String {
+    private fun getCustomTimeoutValue(): String {
      	return binding.activityRepoWebdavCustomTimeoutValue.text.toString().trim { it <= ' ' }
     }
 
-	private fun getCustomConnectionTimeout(): String? {
-		return if (getCustomConnectionTimeoutEnabled()) getCustomConnectionTimeoutValue() else null
+	private fun getCustomTimeout(): String? {
+		return if (getCustomTimeoutEnabled()) getCustomTimeoutValue() else null
 	}
  	   private fun isInputValid(): Boolean {
         val url = getUrl()
         val username = getUsername()
         val password = getPassword()
-		val timeout = getCustomConnectionTimeoutValue()
-		val useCustomTimeout = getCustomConnectionTimeoutEnabled()
+		val timeout = getCustomTimeoutValue()
+		val useCustomTimeout = getCustomTimeoutEnabled()
 
         binding.activityRepoWebdavUrlLayout.error = when {
             TextUtils.isEmpty(url) -> getString(R.string.can_not_be_empty)
@@ -302,9 +302,9 @@ class WebdavRepoActivity : CommonActivity() {
         val username = getUsername()
         val password = getPassword()
         val certificates = getCertificates()
-        val connectionTimeout = getCustomConnectionTimeout()?.toUIntOrNull()
+        val timeout = getCustomTimeout()?.toUIntOrNull()
 
-        viewModel.testConnection(uriString, username, password, certificates, connectionTimeout)
+        viewModel.testConnection(uriString, username, password, certificates, timeout)
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoActivity.kt
@@ -4,12 +4,12 @@ import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
 import android.os.Bundle
+import android.text.InputType
 import android.text.TextUtils
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.WindowManager
-import android.text.InputType 
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -18,9 +18,9 @@ import com.orgzly.android.App
 import com.orgzly.android.repos.RepoFactory
 import com.orgzly.android.repos.RepoType
 import com.orgzly.android.repos.WebdavRepo.Companion.CERTIFICATES_PREF_KEY
+import com.orgzly.android.repos.WebdavRepo.Companion.CUSTOM_TIMEOUT_PREF_KEY
 import com.orgzly.android.repos.WebdavRepo.Companion.PASSWORD_PREF_KEY
 import com.orgzly.android.repos.WebdavRepo.Companion.USERNAME_PREF_KEY
-import com.orgzly.android.repos.WebdavRepo.Companion.CUSTOM_TIMEOUT_PREF_KEY
 import com.orgzly.android.repos.WebdavRepo.Companion.USE_CUSTOM_TIMEOUT_PREF_KEY
 import com.orgzly.android.ui.CommonActivity
 import com.orgzly.android.ui.util.ActivityUtils
@@ -58,7 +58,7 @@ class WebdavRepoActivity : CommonActivity() {
                 binding.activityRepoWebdavCustomTimeoutValueLayout.setEnabled(false)
                 binding.activityRepoWebdavCustomTimeoutValue.inputType = InputType.TYPE_NULL
             }
-        }        
+        }
         val repoId = intent.getLongExtra(ARG_REPO_ID, 0)
         val factory = WebdavRepoViewModelFactory.getInstance(dataRepository, repoId)
 
@@ -123,13 +123,14 @@ class WebdavRepoActivity : CommonActivity() {
 
                 binding.activityRepoWebdavUsername.setText(repoWithProps.props[USERNAME_PREF_KEY])
                 binding.activityRepoWebdavPassword.setText(repoWithProps.props[PASSWORD_PREF_KEY])
-				if(repoWithProps.props[CUSTOM_TIMEOUT_PREF_KEY] != null){
-					binding.activityRepoWebdavCustomTimeoutValue.setText(repoWithProps.props[CUSTOM_TIMEOUT_PREF_KEY])
-				}
-				if (repoWithProps.props[USE_CUSTOM_TIMEOUT_PREF_KEY].toBoolean()){
+                if (repoWithProps.props[CUSTOM_TIMEOUT_PREF_KEY] != null) {
+                    binding.activityRepoWebdavCustomTimeoutValue.setText(
+                            repoWithProps.props[CUSTOM_TIMEOUT_PREF_KEY]
+                    )
+                }
+                if (repoWithProps.props[USE_CUSTOM_TIMEOUT_PREF_KEY].toBoolean()) {
                     binding.activityRepoWebdavCustomTimeoutEnabled.setChecked(true)
-				}
-                else {
+                } else {
                     binding.activityRepoWebdavCustomTimeoutEnabled.setChecked(false)
                 }
                 viewModel.certificates.value = repoWithProps.props[CERTIFICATES_PREF_KEY]
@@ -168,8 +169,8 @@ class WebdavRepoActivity : CommonActivity() {
             val username = getUsername()
             val password = getPassword()
             val certificates = getCertificates()
-			val timeoutValue = getCustomTimeoutValue()
-			val useCustomTimeout = getCustomTimeoutEnabled()
+            val timeoutValue = getCustomTimeoutValue()
+            val useCustomTimeout = getCustomTimeoutEnabled()
 
             val props = mutableMapOf(
                     USERNAME_PREF_KEY to username,
@@ -179,13 +180,13 @@ class WebdavRepoActivity : CommonActivity() {
                 props[CERTIFICATES_PREF_KEY] = certificates
             }
 
-			if (timeoutValue != null) {
+            if (timeoutValue != null) {
                 props[CUSTOM_TIMEOUT_PREF_KEY] = timeoutValue
-			}
+            }
 
-			if (useCustomTimeout) {
-				props[USE_CUSTOM_TIMEOUT_PREF_KEY] = useCustomTimeout.toString()
-			}
+            if (useCustomTimeout) {
+                props[USE_CUSTOM_TIMEOUT_PREF_KEY] = useCustomTimeout.toString()
+            }
 
             if (UriUtils.isUrlSecure(uriString)) {
                 viewModel.saveRepo(RepoType.WEBDAV, uriString, props)
@@ -220,23 +221,24 @@ class WebdavRepoActivity : CommonActivity() {
         return viewModel.certificates.value
     }
 
-	private fun getCustomTimeoutEnabled(): Boolean {
-		return binding.activityRepoWebdavCustomTimeoutEnabled.isChecked
-	}
-
-    private fun getCustomTimeoutValue(): String {
-     	return binding.activityRepoWebdavCustomTimeoutValue.text.toString().trim { it <= ' ' }
+    private fun getCustomTimeoutEnabled(): Boolean {
+        return binding.activityRepoWebdavCustomTimeoutEnabled.isChecked
     }
 
-	private fun getCustomTimeout(): String? {
-		return if (getCustomTimeoutEnabled()) getCustomTimeoutValue() else null
-	}
- 	   private fun isInputValid(): Boolean {
+    private fun getCustomTimeoutValue(): String {
+        return binding.activityRepoWebdavCustomTimeoutValue.text.toString().trim { it <= ' ' }
+    }
+
+    private fun getCustomTimeout(): String? {
+        return if (getCustomTimeoutEnabled()) getCustomTimeoutValue() else null
+    }
+
+    private fun isInputValid(): Boolean {
         val url = getUrl()
         val username = getUsername()
         val password = getPassword()
-		val timeout = getCustomTimeoutValue()
-		val useCustomTimeout = getCustomTimeoutEnabled()
+        val timeout = getCustomTimeoutValue()
+        val useCustomTimeout = getCustomTimeoutEnabled()
 
         binding.activityRepoWebdavUrlLayout.error = when {
             TextUtils.isEmpty(url) -> getString(R.string.can_not_be_empty)
@@ -255,17 +257,19 @@ class WebdavRepoActivity : CommonActivity() {
             else -> null
         }
 
-		binding.activityRepoWebdavCustomTimeoutValueLayout.error = when {
-			!useCustomTimeout -> null
-			TextUtils.isEmpty(timeout) -> getString(R.string.can_not_be_empty)
-			(timeout.toUIntOrNull() == null || timeout.toUInt() > OKHTTP_MAX_TIMEOUT) -> getString(R.string.number_too_large_or_invalid)
-			else -> null
-		}
+        binding.activityRepoWebdavCustomTimeoutValueLayout.error =
+                when {
+                    !useCustomTimeout -> null
+                    TextUtils.isEmpty(timeout) -> getString(R.string.can_not_be_empty)
+                    (timeout.toUIntOrNull() == null || timeout.toUInt() > OKHTTP_MAX_TIMEOUT) ->
+                            getString(R.string.number_too_large_or_invalid)
+                    else -> null
+                }
 
-        return binding.activityRepoWebdavUrlLayout.error == null
-                && binding.activityRepoWebdavUsernameLayout.error == null
-                && binding.activityRepoWebdavPasswordLayout.error == null
-				&& binding.activityRepoWebdavCustomTimeoutValueLayout.error == null
+        return binding.activityRepoWebdavUrlLayout.error == null &&
+                binding.activityRepoWebdavUsernameLayout.error == null &&
+                binding.activityRepoWebdavPasswordLayout.error == null &&
+                binding.activityRepoWebdavCustomTimeoutValueLayout.error == null
     }
 
     fun editCertificates(@Suppress("UNUSED_PARAMETER") view: View) {
@@ -311,7 +315,7 @@ class WebdavRepoActivity : CommonActivity() {
         private const val ARG_REPO_ID = "repo_id"
 
         private val WEB_DAV_SCHEME_REGEX = Regex("^(webdav|dav|http)s?://.+\$")
-		private val OKHTTP_MAX_TIMEOUT = 2147483u
+        private val OKHTTP_MAX_TIMEOUT = 2147483u
 
         @JvmStatic
         @JvmOverloads

--- a/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoViewModel.kt
@@ -24,14 +24,14 @@ class WebdavRepoViewModel(
 
     val connectionTestStatus: MutableLiveData<ConnectionResult> = MutableLiveData()
 
-    fun testConnection(uriString: String, username: String, password: String, certificates: String?) {
+    fun testConnection(uriString: String, username: String, password: String, certificates: String?, connectionTimeout: UInt?) {
         App.EXECUTORS.networkIO().execute {
             try {
                 connectionTestStatus.postValue(ConnectionResult.InProgress(R.string.connecting))
 
                 val uri = Uri.parse(uriString)
 
-                val bookCount = WebdavRepo(repoId, uri, username, password, certificates).run {
+                val bookCount = WebdavRepo(repoId, uri, username, password, certificates, connectionTimeout).run {
                     books.size
                 }
 

--- a/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/webdav/WebdavRepoViewModel.kt
@@ -24,14 +24,14 @@ class WebdavRepoViewModel(
 
     val connectionTestStatus: MutableLiveData<ConnectionResult> = MutableLiveData()
 
-    fun testConnection(uriString: String, username: String, password: String, certificates: String?, connectionTimeout: UInt?) {
+    fun testConnection(uriString: String, username: String, password: String, certificates: String?, customTimeout: UInt?) {
         App.EXECUTORS.networkIO().execute {
             try {
                 connectionTestStatus.postValue(ConnectionResult.InProgress(R.string.connecting))
 
                 val uri = Uri.parse(uriString)
 
-                val bookCount = WebdavRepo(repoId, uri, username, password, certificates, connectionTimeout).run {
+                val bookCount = WebdavRepo(repoId, uri, username, password, certificates, customTimeout).run {
                     books.size
                 }
 

--- a/app/src/main/res/layout/activity_repo_webdav.xml
+++ b/app/src/main/res/layout/activity_repo_webdav.xml
@@ -77,31 +77,31 @@
 
                 </com.google.android.material.textfield.TextInputLayout>
 
-				<com.google.android.material.switchmaterial.SwitchMaterial
-					android:id="@+id/activity_repo_webdav_custom_timeout_enabled"
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/activity_repo_webdav_custom_timeout_enabled"
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
-				    android:text="@string/webdav_custom_timeout_summary"
-					android:checked="@bool/pref_default_custom_timeout_enabled"/>
-        
+                    android:text="@string/webdav_custom_timeout_summary"
+                    android:checked="@bool/pref_default_custom_timeout_enabled"/>
+
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/activity_repo_webdav_custom_timeout_value_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-        			android:layout_marginTop="@dimen/space_between_content_areas"
-					android:enabled="@bool/pref_default_custom_timeout_enabled"
-        			app:errorEnabled="true">
-        
+                    android:layout_marginTop="@dimen/space_between_content_areas"
+                    android:enabled="@bool/pref_default_custom_timeout_enabled"
+                    app:errorEnabled="true">
+
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/activity_repo_webdav_custom_timeout_value"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-						android:hint="@string/webdav_custom_timeout_hint"
+                        android:hint="@string/webdav_custom_timeout_hint"
                         android:inputType="number"
-						android:text="@string/pref_default_webdav_custom_timeout_value"
-					    android:enabled="@bool/pref_default_custom_timeout_enabled"
+                        android:text="@string/pref_default_webdav_custom_timeout_value"
+                        android:enabled="@bool/pref_default_custom_timeout_enabled"
                         app:min="0" />
-
+    
                 </com.google.android.material.textfield.TextInputLayout>
 
 

--- a/app/src/main/res/layout/activity_repo_webdav.xml
+++ b/app/src/main/res/layout/activity_repo_webdav.xml
@@ -77,26 +77,27 @@
 
                 </com.google.android.material.textfield.TextInputLayout>
 
-				<SwitchPreference
-					android:id="@+id/activity_repo_webdav_enable_custom_timeout"
-					android:title="@string/webdav_enable_custom_timeout"
-				    android:summary="@string/webdav_custom_timeout_summary"
-					android:defaultValue="@bool/pref_custom_timeout_enabled">
+				<com.google.android.material.switchmaterial.SwitchMaterial
+					android:id="@+id/activity_repo_webdav_custom_timeout_enabled"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+				    android:text="@string/webdav_custom_timeout_summary"
+					android:checked="@bool/pref_custom_timeout_enabled"/>
         
                 <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/activity_repo_webdav_timeout_value_layout"
+                    android:id="@+id/activity_repo_webdav_custom_timeout_value_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
         			android:layout_marginTop="@dimen/space_between_content_areas"
-        			app:errorEnabled="true"
-					android:dependency="@+id/activity_repo_webdav_enable_custom_timeout">
+        			app:errorEnabled="true">
         
                     <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/activity_repo_webdav_timeout_value"
+                        android:id="@+id/activity_repo_webdav_custom_timeout_value"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
 						android:hint="@string/webdav_timeout_hint"
                         android:inputType="number"
+						android:text="@string/webdav_custom_timeout_value_default"
                         app:min="0" />
 
                 </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/activity_repo_webdav.xml
+++ b/app/src/main/res/layout/activity_repo_webdav.xml
@@ -77,6 +77,31 @@
 
                 </com.google.android.material.textfield.TextInputLayout>
 
+				<SwitchPreference
+					android:id="@+id/activity_repo_webdav_enable_custom_timeout"
+					android:title="@string/webdav_enable_custom_timeout"
+				    android:summary="@string/webdav_custom_timeout_summary"
+					android:defaultValue="@bool/pref_custom_timeout_enabled">
+        
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/activity_repo_webdav_timeout_value_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+        			android:layout_marginTop="@dimen/space_between_content_areas"
+        			app:errorEnabled="true"
+					android:dependency="@+id/activity_repo_webdav_enable_custom_timeout">
+        
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/activity_repo_webdav_timeout_value"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+						android:hint="@string/webdav_timeout_hint"
+                        android:inputType="number"
+                        app:min="0" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+
                 <Button
                     android:id="@+id/activity_repo_webdav_test_button"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_repo_webdav.xml
+++ b/app/src/main/res/layout/activity_repo_webdav.xml
@@ -82,24 +82,24 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
 				    android:text="@string/webdav_custom_timeout_summary"
-					android:checked="@bool/pref_custom_timeout_enabled"/>
+					android:checked="@bool/pref_default_custom_timeout_enabled"/>
         
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/activity_repo_webdav_custom_timeout_value_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
         			android:layout_marginTop="@dimen/space_between_content_areas"
-					android:enabled="@bool/pref_custom_timeout_enabled"
+					android:enabled="@bool/pref_default_custom_timeout_enabled"
         			app:errorEnabled="true">
         
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/activity_repo_webdav_custom_timeout_value"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-						android:hint="@string/webdav_timeout_hint"
+						android:hint="@string/webdav_custom_timeout_hint"
                         android:inputType="number"
-						android:text="@string/webdav_custom_timeout_value_default"
-					    android:enabled="@bool/pref_custom_timeout_enabled"
+						android:text="@string/pref_default_webdav_custom_timeout_value"
+					    android:enabled="@bool/pref_default_custom_timeout_enabled"
                         app:min="0" />
 
                 </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/activity_repo_webdav.xml
+++ b/app/src/main/res/layout/activity_repo_webdav.xml
@@ -89,6 +89,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
         			android:layout_marginTop="@dimen/space_between_content_areas"
+					android:enabled="@bool/pref_custom_timeout_enabled"
         			app:errorEnabled="true">
         
                     <com.google.android.material.textfield.TextInputEditText
@@ -98,6 +99,7 @@
 						android:hint="@string/webdav_timeout_hint"
                         android:inputType="number"
 						android:text="@string/webdav_custom_timeout_value_default"
+					    android:enabled="@bool/pref_custom_timeout_enabled"
                         app:min="0" />
 
                 </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -563,7 +563,7 @@
     <string name="content">Inhalt</string>
     <string name="prepend">Voranstellen</string>
     <string name="insert_new_note_at_beginning">Neue Notiz am Anfang einfügen</string>
-    <string name="webdav_custom_timeout_hint">Timeout für Serververbindungen (in Sekunden), 0 bedeutet kein Timeout</string>
+    <string name="webdav_custom_timeout_hint">Timeout (in Sekunden), 0 bedeutet kein Timeout</string>
     <string name="webdav_custom_timeout_summary">Benutzerdefiniertes Timeout für Serververbindungen nutzen</string>
     <string name="number_too_large_or_invalid">Zu große oder ungültige Zahl</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -563,4 +563,7 @@
     <string name="content">Inhalt</string>
     <string name="prepend">Voranstellen</string>
     <string name="insert_new_note_at_beginning">Neue Notiz am Anfang einfügen</string>
+    <string name="webdav_custom_timeout_hint">Timeout für Serververbindungen (in Sekunden), 0 bedeutet kein Timeout</string>
+    <string name="webdav_custom_timeout_summary">Benutzerdefiniertes Timeout für Serververbindungen nutzen</string>
+    <string name="number_too_large_or_invalid">Zu große oder ungültige Zahl</string>
 </resources>

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -546,4 +546,6 @@
     <string name="pref_key_is_note_content_folded" translatable="false">pref_key_is_note_content_folded</string>
     <bool name="pref_default_is_note_content_folded" translatable="false">false</bool>
 
+	<bool name="pref_custom_timeout_enabled" translatable="false">false</bool>
+
 </resources>

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -546,6 +546,7 @@
     <string name="pref_key_is_note_content_folded" translatable="false">pref_key_is_note_content_folded</string>
     <bool name="pref_default_is_note_content_folded" translatable="false">false</bool>
 
-	<bool name="pref_custom_timeout_enabled" translatable="false">false</bool>
+	<bool name="pref_default_custom_timeout_enabled" translatable="false">false</bool>
+	<string name="pref_default_webdav_custom_timeout_value" translatable="false">10</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,7 +253,7 @@
     <string name="title_can_not_be_empty">Title cannot be empty</string>
     <string name="can_not_be_empty">Cannot be empty</string>
     <string name="invalid_url">Invalid URL</string>
-	<string name="invalid_number">Invalid number</string>
+	<string name="number_too_large_or_invalid">Number too large or invalid number</string>
 
     <string name="no_notebooks">You have no notebooks</string>
     <string name="no_notes">Notebook has no notes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,7 +224,7 @@
     <string name="webdav_auth_password_hint">Password</string>
     <string name="webdav_test_error_auth">Login or password is invalid</string>
     <string name="webdav_test_error_unknown">Unknown error occurred</string>
-	<string name="webdav_custom_timeout_hint">Timeout (in seconds) for server connection, 0 means no timeout</string>
+	<string name="webdav_custom_timeout_hint">Timeout (in seconds), 0 for no timeout</string>
 	<string name="webdav_custom_timeout_summary">Use custom timeout for connection to server</string>
 
     <!-- Share button - error messages (set as title). -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,8 @@
     <string name="webdav_test_error_auth">Login or password is invalid</string>
     <string name="webdav_test_error_unknown">Unknown error occurred</string>
 	<string name="webdav_timeout_hint">Timeout for server connection (seconds), 0 means no timeout</string>
+	<string name="webdav_custom_timeout_summary">Use custom timeout for connection to server</string>
+	<string name="webdav_custom_timeout_value_default">10</string>
 
     <!-- Share button - error messages (set as title). -->
     <string name="share_action_not_set">Share action not set</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,9 +224,8 @@
     <string name="webdav_auth_password_hint">Password</string>
     <string name="webdav_test_error_auth">Login or password is invalid</string>
     <string name="webdav_test_error_unknown">Unknown error occurred</string>
-	<string name="webdav_timeout_hint">Timeout for server connection (seconds), 0 means no timeout</string>
+	<string name="webdav_custom_timeout_hint">Timeout (in seconds) for server connection, 0 means no timeout</string>
 	<string name="webdav_custom_timeout_summary">Use custom timeout for connection to server</string>
-	<string name="webdav_custom_timeout_value_default">10</string>
 
     <!-- Share button - error messages (set as title). -->
     <string name="share_action_not_set">Share action not set</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,7 @@
     <string name="webdav_auth_password_hint">Password</string>
     <string name="webdav_test_error_auth">Login or password is invalid</string>
     <string name="webdav_test_error_unknown">Unknown error occurred</string>
+	<string name="webdav_timeout_hint">Timeout for server connection (seconds), 0 means no timeout</string>
 
     <!-- Share button - error messages (set as title). -->
     <string name="share_action_not_set">Share action not set</string>
@@ -250,6 +251,7 @@
     <string name="title_can_not_be_empty">Title cannot be empty</string>
     <string name="can_not_be_empty">Cannot be empty</string>
     <string name="invalid_url">Invalid URL</string>
+	<string name="invalid_number">Invalid number</string>
 
     <string name="no_notebooks">You have no notebooks</string>
     <string name="no_notes">Notebook has no notes</string>


### PR DESCRIPTION
Hey, I think this pull request would do the job of enabling a custom timeout for WebDAV repos which
have a problem when syncing because the server is too slow (see #870).

This change would use a user-defined value (in seconds) for all three different timeouts which one can set
with OkHttp (connectTimeout, readTimeout, writeTimeout). I thought this would be better for simplicity.

UI would look like this:
![customTimeout](https://user-images.githubusercontent.com/29584865/129456466-cee466e5-5bfb-41ef-ab29-e83ba89f0457.png)

I've tested this with my nextcloud, it seems to be working so far.