### PR TITLE
Android R+: request MANAGE_EXTERNAL_STORAGE when creating new git repos

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
 
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+
     <!-- For BroadcastReceiver below -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 

--- a/app/src/main/java/com/orgzly/android/ui/repos/ReposActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repos/ReposActivity.kt
@@ -1,9 +1,13 @@
 package com.orgzly.android.ui.repos
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.Settings
 import android.view.ContextMenu
 import android.view.MenuItem
 import android.view.View
@@ -28,6 +32,7 @@ import com.orgzly.android.ui.repo.webdav.WebdavRepoActivity
 import com.orgzly.android.ui.showSnackbar
 import com.orgzly.databinding.ActivityReposBinding
 import javax.inject.Inject
+
 
 /**
  * List of user-configured repositories.
@@ -220,14 +225,18 @@ class ReposActivity : CommonActivity(), AdapterView.OnItemClickListener, Activit
             }
 
             R.id.repos_options_menu_item_new_git -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-                    GitRepoActivity.start(this)
-                } else {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
+                    val uri = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
+                    startActivity(
+                        Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, uri))
+                } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R && ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
                     // TODO: Show explanation why possibly, if ActivityCompat.shouldShowRequestPermissionRationale() says so?
                     ActivityCompat.requestPermissions(
                         this,
                         arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
                         ACTIVITY_REQUEST_CODE_FOR_READ_WRITE_EXTERNAL_STORAGE)
+                } else {
+                    GitRepoActivity.start(this)
                 }
                 return
             }


### PR DESCRIPTION
I think this also needs requesting on sync or upgrade, in case the app/OS is updated or the permission revoked, but as that's more async I'm not sure where to do it. Just adding the manifest entry makes it possible to manually grant it for now in that case.

An alternative would be to use only app-specific directories permitted under scoped storage, or to perhaps use newer file access APIs to have the user grant fine-grained access? But those'd be larger refactors and this unblocks it for now.

This is a rebase of https://github.com/orgzly/orgzly-android/pull/910, see also https://github.com/orgzly/orgzly-android/issues/24#issuecomment-1025506911