### PR TITLE
Apply author/email to the repository, so it also gets used for merges

### DIFF
--- a/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
+++ b/app/src/main/java/com/orgzly/android/git/GitFileSynchronizer.java
@@ -363,11 +363,7 @@ public class GitFileSynchronizer {
     }
 
     private void commit(String message) throws GitAPIException {
-        Context context = App.getAppContext();
-        git.commit().setCommitter(
-                preferences.getAuthor(),
-                preferences.getEmail()).
-                setMessage(message).call();
+        git.commit().setMessage(message).call();
     }
 
     public RevCommit currentHead() throws IOException {

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -69,6 +69,8 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
 
         StoredConfig config = git.getRepository().getConfig();
         config.setString("remote", prefs.remoteName(), "url", prefs.remoteUri().toString());
+        config.setString("user", null, "name", prefs.getAuthor());
+        config.setString("user", null, "email", prefs.getEmail());
         config.save();
 
         return new GitRepo(id, git, prefs);


### PR DESCRIPTION
Previously, it was applied only for regular commits, and merges were
attributed to `root`. jgit seems to have no way to specify the comitter,
but it does read from the repo config.