### PR TITLE
Add app preference for remove node indent

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -423,6 +423,17 @@ public class AppPreferences {
         getDefaultSharedPreferences(context).edit().putBoolean(key, value).apply();
     }
 
+    public static boolean isRemoveNoteIndent(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_is_remove_indent),
+                context.getResources().getBoolean(R.bool.pref_default_is_remove_indent));
+    }
+
+    public static void isRemoveNoteIndent(Context context, boolean value) {
+        String key = context.getResources().getString(R.string.pref_key_is_remove_indent);
+        getDefaultSharedPreferences(context).edit().putBoolean(key, value).apply();
+    }
+
     /*
      * Schedule new note.
      */

--- a/app/src/main/java/com/orgzly/android/ui/notes/NoteItemViewBinder.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NoteItemViewBinder.kt
@@ -103,7 +103,14 @@ class NoteItemViewBinder(private val context: Context, private val inBook: Boole
     }
 
     private fun setupTitle(holder: NoteItemViewHolder, noteView: NoteView) {
-        holder.binding.itemHeadTitle.setText(generateTitle(noteView))
+        val level = if (inBook) noteView.note.position.level else 0
+
+        if (AppPreferences.isRemoveNoteIndent(context)) {
+            holder.binding.itemHeadTitle.setText("--".repeat(level)+"  "+generateTitle(noteView))
+        }
+        else {
+            holder.binding.itemHeadTitle.setText(generateTitle(noteView))
+        }
     }
 
     fun generateTitle(noteView: NoteView): CharSequence {
@@ -244,28 +251,33 @@ class NoteItemViewBinder(private val context: Context, private val inBook: Boole
         val container = holder.binding.itemHeadIndentContainer
 
         val level = if (inBook) note.position.level - 1 else 0
+        var titleIndentLevel = level
+
+        if (AppPreferences.isRemoveNoteIndent(context)) {
+            titleIndentLevel = 0
+        }
 
         when {
-            container.childCount < level -> { // More levels needed
+            container.childCount < titleIndentLevel -> { // More levels needed
                 // Make all existing levels visible
                 for (i in 1..container.childCount) {
                     container.getChildAt(i - 1).visibility = View.VISIBLE
                 }
 
                 // Inflate the rest
-                for (i in container.childCount + 1..level) {
+                for (i in container.childCount + 1..titleIndentLevel) {
                     View.inflate(container.context, R.layout.indent, container)
                 }
             }
 
-            level < container.childCount -> { // Too many levels
+            titleIndentLevel< container.childCount -> { // Too many levels
                 // Make required levels visible
-                for (i in 1..level) {
+                for (i in 1..titleIndentLevel) {
                     container.getChildAt(i - 1).visibility = View.VISIBLE
                 }
 
                 // Hide the rest
-                for (i in level + 1..container.childCount) {
+                for (i in titleIndentLevel + 1..container.childCount) {
                     container.getChildAt(i - 1).visibility = View.GONE
                 }
             }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -282,6 +282,8 @@
     <string name="monospaced_font_summary">为笔记内容和笔记本序言使用等宽字体</string>
     <string name="reversed_note_click_action">反转笔记点击动作</string>
     <string name="reversed_note_click_action_summary">点击选择笔记，长按打开笔记</string>
+    <string name="remove_note_indent">移除笔记缩进</string>
+    <string name="remove_mote_indent_summary">移除笔记缩进以节省屏幕空间</string>
     <string name="look_and_feel">外观 &amp; 感觉</string>
     <string name="notes_list">笔记列表</string>
     <string name="prefs_title_new_note">新建笔记</string>

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -25,6 +25,9 @@
     <string name="pref_key_is_reverse_click_action" translatable="false">pref_key_is_reverse_click_action</string>
     <bool name="pref_default_is_reverse_click_action" translatable="false">false</bool>
 
+    <string name="pref_key_is_remove_indent" translatable="false">pref_key_is_remove_indent</string>
+    <bool name="pref_default_is_remove_indent" translatable="false">false</bool>
+
     <string name="pref_key_is_notes_content_displayed_in_list" translatable="false">pref_key_is_notes_content_displayed_in_list</string>
     <bool name="pref_default_is_notes_content_displayed_in_list" translatable="false">true</bool>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,6 +328,8 @@
     <string name="monospaced_font_summary">Use monospaced font for note\'s content and notebook\'s preface</string>
     <string name="reversed_note_click_action">Swap note click and long-click actions</string>
     <string name="reversed_note_click_action_summary">Click to select note, long-click to open</string>
+    <string name="remove_note_indent">Remove note indent</string>
+    <string name="remove_mote_indent_summary">Remove note indent to save screen space</string>
     <string name="look_and_feel">Look &amp; Feel</string>
     <string name="notes_list">List of notes</string>
     <string name="prefs_title_new_note">New note</string>

--- a/app/src/main/res/xml/prefs_screen_look_and_feel.xml
+++ b/app/src/main/res/xml/prefs_screen_look_and_feel.xml
@@ -11,6 +11,12 @@
         android:summary="@string/reversed_note_click_action_summary"
         android:defaultValue="@bool/pref_default_is_reverse_click_action"/>
 
+    <SwitchPreference
+        android:key="@string/pref_key_is_remove_indent"
+        android:title="@string/remove_note_indent"
+        android:summary="@string/remove_mote_indent_summary"
+        android:defaultValue="@bool/pref_default_is_remove_indent"/>
+
     <ListPreference
         android:key="@string/pref_key_color_scheme"
         android:title="@string/color_scheme"


### PR DESCRIPTION
Hi, I add some code for the https://github.com/orgzly/orgzly-android/issues/950#issue-1317846293,

currently notebook without indent will look like this:

```
--  h1
----  h2
------  h3
body of h3
```