### PR TITLE
Add setting for making reminder notifications sticky

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -302,6 +302,12 @@ public class AppPreferences {
                 context.getResources().getBoolean(R.bool.pref_default_reminders_vibrate));
     }
 
+    public static boolean remindersSticky(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_reminders_sticky),
+                context.getResources().getBoolean(R.bool.pref_default_reminders_sticky));
+    }
+
     public static int remindersSnoozeTime(Context context) {
         return Integer.parseInt(getDefaultSharedPreferences(context).getString(
                 context.getResources().getString(R.string.pref_key_snooze_time),

--- a/app/src/main/java/com/orgzly/android/reminders/RemindersNotifications.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/RemindersNotifications.kt
@@ -53,6 +53,12 @@ object RemindersNotifications {
                 builder.setVibrate(VIBRATION_PATTERN)
             }
 
+            // Set notification sticky
+            if (AppPreferences.remindersSticky(context)) {
+                builder.setOngoing(true)
+                builder.setAutoCancel(false)
+            }
+
             // Set notification sound
             if (AppPreferences.remindersSound(context)) {
                 builder.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -257,6 +257,9 @@
     <string name="pref_key_reminders_vibrate" translatable="false">pref_key_reminders_vibrate</string>
     <bool name="pref_default_reminders_vibrate" translatable="false">false</bool>
 
+    <string name="pref_key_reminders_sticky" translatable="false">pref_key_reminders_sticky</string>
+    <bool name="pref_default_reminders_sticky" translatable="false">false</bool>
+
     <string name="pref_key_reminders_led" translatable="false">pref_key_reminders_led</string>
     <bool name="pref_default_reminders_led" translatable="false">true</bool>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,6 +474,9 @@
     <string name="pref_title_reminders_for_event_times">Events</string>
     <string name="pref_title_summary_reminders_for_event_times">Display notification for notes with event time</string>
 
+    <string name="pref_title_reminders_remindersSticky">Sticky Reminders"</string>
+    <string name="pref_title_summary_remindersSticky">Reminders cannot be dismissed by swiping</string>
+
     <string name="pref_title_reminders_sound">Sound</string>
     <string name="pref_title_reminders_vibrate">Vibration</string>
     <string name="pref_title_reminders_led">Light</string>

--- a/app/src/main/res/xml-v26/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml-v26/prefs_screen_reminders.xml
@@ -23,6 +23,12 @@
         android:summary="@string/pref_title_summary_reminders_for_event_times"
         android:defaultValue="@bool/pref_default_use_reminders_for_event_times" />
 
+    <SwitchPreference
+        android:key="@string/pref_key_reminders_sticky"
+        android:title="@string/pref_title_reminders_remindersSticky"
+        android:summary="@string/pref_title_summary_remindersSticky"
+        android:defaultValue="@bool/pref_default_reminders_sticky" />
+
     <com.orgzly.android.prefs.TimePreference
         android:key="@string/pref_key_daily_reminder_time"
         android:title="@string/pref_title_daily_reminder_time" />

--- a/app/src/main/res/xml/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml/prefs_screen_reminders.xml
@@ -23,6 +23,12 @@
         android:summary="@string/pref_title_summary_reminders_for_event_times"
         android:defaultValue="@bool/pref_default_use_reminders_for_event_times" />
 
+    <SwitchPreference
+        android:key="@string/pref_key_reminders_sticky"
+        android:title="@string/pref_title_reminders_remindersSticky"
+        android:summary="@string/pref_title_summary_remindersSticky"
+        android:defaultValue="@bool/pref_default_reminders_sticky" />
+
     <com.orgzly.android.prefs.TimePreference
         android:key="@string/pref_key_daily_reminder_time"
         android:title="@string/pref_title_daily_reminder_time" />


### PR DESCRIPTION
Implements a sticky reminders feature that was previously suggested in https://github.com/orgzly/orgzly-android/issues/107 and https://github.com/orgzly/orgzly-android/issues/621

Like others have mentioned in the related issues, this is a feature that some other apps have. I had previously used [p!n](https://github.com/nproth/pin)  for doing just this but it would be nice to be able to use Orgzly instead.

The code change is based on the PR https://github.com/orgzly/orgzly-android/pull/843. I have been using a build with this change over the past few days and I have not faced any issues with it.