### PR TITLE
Shorten the UK-UA translation for "Last synchronized"

### DIFF
--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -306,7 +306,7 @@
     <string name="connecting">Зʼєднання…</string>
     <string name="no_connection">Відсутнє зʼєднання</string>
     <string name="connection_successful">Зʼєднання успішне</string>
-    <string name="last_sync_with_argument">Востаннє синхронізовано: %s</string>
+    <string name="last_sync_with_argument">Синхронізовано: %s</string>
     <string name="force_loading_from_uri">Примусове завантаження з %s…</string>
     <string name="force_loaded_from_uri">Примусово завантажено з %s</string>
     <string name="force_saving_to_uri">Примусове зберігання в %s…</string>


### PR DESCRIPTION
Unlike the english original, the phrase and the actual timestamp does not fit on the standard 5" display.
![IMG_20220918_150356](https://user-images.githubusercontent.com/4975074/192304090-acb2316e-3c14-45b2-bc6a-8293156247b1.jpg)
