### PR TITLE
Make period description fully visible

### DIFF
--- a/app/src/main/res/layout/dialog_period_with_type.xml
+++ b/app/src/main/res/layout/dialog_period_with_type.xml
@@ -23,8 +23,7 @@
             app:layout_constraintLeft_toLeftOf="@id/pickers"
             app:layout_constraintRight_toRightOf="@+id/pickers"
             tools:text="@string/repeater_description"
-            android:gravity="center"
-            android:lines="2" />
+            android:gravity="center" />
 
         <LinearLayout
             android:id="@+id/pickers"


### PR DESCRIPTION
The current limit of 2 lines means that the full description is not shown on my device.

I don't think the change that I've made here does what I wanted it to, so this PR can just be a kind of issue, maybe?

Unfortunately I don't have a USB-c cable handy and this computer doesn't support the android emulator, so it's quite hard to develop the app!