### PR TITLE
Monochrome vector launcher icon for adaptive-icons support

### DIFF
--- a/app/src/main/res/drawable/cic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/cic_launcher_monochrome.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group android:scaleX="1.0125"
+        android:scaleY="1.0125"
+        android:translateX="21.6"
+        android:translateY="21.6">
+        <path
+            android:pathData="m50,16.813c0,-1.552 -1.12,-2.812 -2.5,-2.812L16.5,14c-1.38,0 -2.5,1.261 -2.5,2.812 0,1.553 1.12,2.812 2.5,2.812l31,0c1.38,0 2.5,-1.26 2.5,-2.812z"
+            android:fillColor="#000000"/>
+        <path
+            android:pathData="m50,47.188c0,-1.552 -1.12,-2.812 -2.5,-2.812L16.5,44.375c-1.38,0 -2.5,1.261 -2.5,2.812 0,1.553 1.12,2.812 2.5,2.812l31,0c1.38,0 2.5,-1.26 2.5,-2.812z"
+            android:fillColor="#000000"/>
+        <path
+            android:pathData="m50,37.063c0,-1.552 -1.21,-2.812 -2.7,-2.812L25.7,34.25c-1.49,0 -2.7,1.261 -2.7,2.812 0,1.553 1.21,2.812 2.7,2.812l21.6,0c1.49,0 2.7,-1.26 2.7,-2.812z"
+            android:fillColor="#000000"/>
+        <path
+            android:pathData="m50,26.938c0,-1.552 -1.21,-2.812 -2.7,-2.812L25.7,24.125c-1.49,0 -2.7,1.261 -2.7,2.812 0,1.553 1.21,2.812 2.7,2.812l21.6,0c1.49,0 2.7,-1.26 2.7,-2.812z"
+            android:fillColor="#000000"/>
+    </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/cic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/cic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/cic_launcher_background"/>
     <foreground android:drawable="@drawable/cic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/cic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
This is primarily an Android 13 / "Material You" detail ([reference](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive)).  The monochrome option is just the existing foreground icon with extraneous detail tidied up.

Before:
<img src="https://user-images.githubusercontent.com/56747/210195934-3fb4957f-6072-447f-a0fd-adea356f06b6.png" width="200">

After:
<img src="https://user-images.githubusercontent.com/56747/210195940-bf028b94-0639-49e3-b71c-54281ce7180b.png" width="200">

