### PR TITLE
Consider time and date ranges when querying events

### DIFF
--- a/app/src/main/java/com/orgzly/android/db/dao/NoteViewDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/NoteViewDao.kt
@@ -91,6 +91,7 @@ abstract class NoteViewDao {
 
             NULL AS event_string,
             NULL AS event_timestamp,
+            NULL AS event_end_timestamp,
             NULL AS event_start_of_day,
             NULL AS event_hour,
 
@@ -152,6 +153,7 @@ abstract class NoteViewDao {
 
             t_note_events_start.string AS event_string,
             t_note_events_start.timestamp AS event_timestamp,
+            COALESCE(t_note_events_start.end_timestamp, t_note_events_end.timestamp, t_note_events_start.timestamp) AS event_end_timestamp,
             datetime(t_note_events_start.timestamp/1000, 'unixepoch', 'localtime', 'start of day') AS event_start_of_day,
             t_note_events_start.hour AS event_hour,
 
@@ -178,6 +180,7 @@ abstract class NoteViewDao {
             LEFT JOIN note_events t_note_events ON t_note_events.note_id = notes.id
             LEFT JOIN org_ranges t_note_events_range ON t_note_events_range.id = t_note_events.org_range_id
             LEFT JOIN org_timestamps t_note_events_start ON t_note_events_start.id = t_note_events_range.start_timestamp_id
+            LEFT JOIN org_timestamps t_note_events_end ON t_note_events_end.id = t_note_events_range.end_timestamp_id
 
             GROUP BY notes.id, event_timestamp
         """

--- a/app/src/main/java/com/orgzly/android/db/entity/NoteView.kt
+++ b/app/src/main/java/com/orgzly/android/db/entity/NoteView.kt
@@ -61,6 +61,8 @@ data class NoteView(
         val eventString : String? = null,
         @ColumnInfo(name = "event_timestamp")
         val eventTimestamp: Long? = null,
+        @ColumnInfo(name = "event_end_timestamp")
+        val eventEndTimestamp: Long? = null,
         @ColumnInfo(name = "event_start_of_day")
         val eventStartOfDay : Long? = null,
         @ColumnInfo(name = "event_hour")

--- a/app/src/main/java/com/orgzly/android/query/sql/SqliteQueryBuilder.kt
+++ b/app/src/main/java/com/orgzly/android/query/sql/SqliteQueryBuilder.kt
@@ -230,7 +230,14 @@ class SqliteQueryBuilder(val context: Context) {
             }
 
             is Condition.Event -> {
-                toInterval("event_timestamp", null, expr.interval, expr.relation)
+                when (expr.relation) {
+                    Relation.EQ -> "(${toInterval("event_timestamp", null, expr.interval, Relation.GE)} AND ${toInterval("event_end_timestamp", null, expr.interval, Relation.LE)})"
+                    Relation.NE -> "(${toInterval("event_timestamp", null, expr.interval, Relation.LT)} AND ${toInterval("event_end_timestamp", null, expr.interval, Relation.GT)})"
+                    Relation.LT,
+                    Relation.LE -> toInterval("event_timestamp", null, expr.interval, expr.relation)
+                    Relation.GT,
+                    Relation.GE -> toInterval("event_end_timestamp", null, expr.interval, expr.relation)
+                }
             }
 
             is Condition.Scheduled -> {


### PR DESCRIPTION
Progress towards #644 

I've opted to use the end timestamp for GT/GE queries, the start timestamp for LT/LE queries and both for EQ/NE queries. This solves the biggest issue for me, namely showing an event while it still happening with a GT query.