### PR TITLE
Add support for TLSv1.2 for WebDAV in Android 4.x

### DIFF
--- a/app/src/main/java/com/orgzly/android/util/TLSSocketFactory.kt
+++ b/app/src/main/java/com/orgzly/android/util/TLSSocketFactory.kt
@@ -1,0 +1,85 @@
+package com.orgzly.android.util
+
+import java.io.IOException
+import java.net.InetAddress
+import java.net.Socket
+import java.net.UnknownHostException
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.X509TrustManager
+
+
+class TLSSocketFactory (trustManager: X509TrustManager) : SSLSocketFactory() {
+    private val internalSSLSocketFactory: SSLSocketFactory
+
+    init {
+        val context = SSLContext.getInstance("TLS")
+        context.init(null, arrayOf(trustManager), null)
+        internalSSLSocketFactory = context.socketFactory
+    }
+
+    override fun getDefaultCipherSuites(): Array<String> {
+        return internalSSLSocketFactory.defaultCipherSuites
+    }
+
+    override fun getSupportedCipherSuites(): Array<String> {
+        return internalSSLSocketFactory.supportedCipherSuites
+    }
+
+    @Throws(IOException::class)
+    override fun createSocket(s: Socket, host: String, port: Int, autoClose: Boolean): Socket {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose))
+    }
+
+    @Throws(IOException::class, UnknownHostException::class)
+    override fun createSocket(host: String, port: Int): Socket {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port))
+    }
+
+    @Throws(IOException::class)
+    override fun createSocket(
+        host: String,
+        port: Int,
+        localHost: InetAddress,
+        localPort: Int
+    ): Socket {
+        return enableTLSOnSocket(
+            internalSSLSocketFactory.createSocket(
+                host,
+                port,
+                localHost,
+                localPort
+            )
+        )
+    }
+
+    @Throws(IOException::class)
+    override fun createSocket(host: InetAddress, port: Int): Socket {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port))
+    }
+
+    @Throws(IOException::class)
+    override fun createSocket(
+        address: InetAddress,
+        port: Int,
+        localAddress: InetAddress,
+        localPort: Int
+    ): Socket {
+        return enableTLSOnSocket(
+            internalSSLSocketFactory.createSocket(
+                address,
+                port,
+                localAddress,
+                localPort
+            )
+        )
+    }
+
+    private fun enableTLSOnSocket(socket: Socket): Socket {
+        if (socket is SSLSocket) {
+            socket.enabledProtocols = arrayOf("TLSv1.2", "TLSv1.1")
+        }
+        return socket
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ buildscript {
 
     versions.glide = '4.10.0'
 
-    versions.sardine = '0.5'
+    versions.sardine = '0.4'
 
     versions.jgit = '4.4.1.201607150455-r'
 


### PR DESCRIPTION
**NOTE:** I am aware that this project is currently unmaintained, and even so this change would not make it in as support for pre-5.0 Android versions was dropped in version 1.8.6.

This PR is intended with pushing a patch and APK I had to create to get WebDAV working with modern TLS on an old Android device (or, more specifically, a Blackberry Q10 running its Android emulator). Other people might find it useful. The base of this PR is the `v1.8.5` tag.

Android 4.1 to 5.0 have support for TLSv1.2 in creating encrypted sockets, but this is (for some reason) disabled by default. This commit adds conditional support for using a TLS socket override with added support for TLSv1.2 in these SDK build versions, in making WebDAV connections.